### PR TITLE
enabling session.post to accept a hash as data and post it as a urlencoded form

### DIFF
--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -150,8 +150,12 @@ module Patron
     end
 
     # Uploads the passed +data+ to the specified +url+ using HTTP POST. +data+
-    # must be a string.
+    # can be a string or a hash.
     def post(url, data, headers = {})
+      if data.is_a?(Hash)
+        data = data.map {|k,v| urlencode(k.to_s) + '=' + urlencode(v.to_s) }.join('&')
+        headers['Content-Type'] = 'application/x-www-form-urlencoded'
+      end
       request(:post, url, headers, :data => data)
     end
 
@@ -214,5 +218,12 @@ module Patron
 
       handle_request(req)
     end
+
+    private
+
+    def urlencode(str)
+      str.gsub(/[^a-zA-Z0-9_\.\-]/n) {|s| sprintf('%%%02x', s[0]) }
+    end
+
   end
 end

--- a/script/test_server
+++ b/script/test_server
@@ -36,11 +36,16 @@ class URI::Parser
   end
 end
 
-class TestServlet < HTTPServlet::AbstractServlet
+module RespondWith
   def respond_with(method, req, res)
     res.body = req.to_yaml
     res['Content-Type'] = "text/plain"
   end
+end
+
+class TestServlet < HTTPServlet::AbstractServlet
+
+  include RespondWith
 
   def do_GET(req,res)
     respond_with(:GET, req, res)
@@ -76,6 +81,16 @@ class RedirectServlet < HTTPServlet::AbstractServlet
   end
 end
 
+
+class TestPostBodyServlet < HTTPServlet::AbstractServlet
+  include RespondWith
+  def do_POST(req, res)
+    respond_with(:POST, {'body' => req.body, 'content_type' => req.content_type}, res)
+  end
+end
+
+
+
 class SetCookieServlet < HTTPServlet::AbstractServlet
   def do_GET(req, res)
     res['Set-Cookie'] = "session_id=foo123"
@@ -104,6 +119,7 @@ end
 
 server = WEBrick::HTTPServer.new :Port => 9001
 server.mount("/test", TestServlet)
+server.mount("/testpost", TestPostBodyServlet)
 server.mount("/timeout", TimeoutServlet)
 server.mount("/redirect", RedirectServlet)
 server.mount("/setcookie", SetCookieServlet)

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -23,6 +23,7 @@
 ## -------------------------------------------------------------------
 require File.expand_path("./spec") + '/spec_helper.rb'
 require 'webrick'
+require 'yaml'
 require 'base64'
 require 'fileutils'
 
@@ -163,6 +164,15 @@ describe Patron::Session do
     body = YAML::load(response.body)
     body.request_method.should == "POST"
     body.header['content-length'].should == [data.size.to_s]
+  end
+
+  it "should post a hash of arguments as a urlencoded form" do
+    data = {:foo => 123, 'baz' => '++hello world++'}
+    response = @session.post("/testpost", data)
+    body = YAML::load(response.body)
+    body['content_type'].should == "application/x-www-form-urlencoded"
+    body['body'].should match('baz=%2b%2bhello%20world%2b%2b')
+    body['body'].should match('foo=123')
   end
 
   it "should raise when no data is provided to :post" do


### PR DESCRIPTION
enabling session.post to accept a hash as data and post it as a urlencoded form
