### PR TITLE
Enable "rb_thread_blocking_region" by default 

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -414,7 +414,7 @@ static VALUE perform_request(VALUE self) {
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, body_buffer);
   }
 
-#if defined(HAVE_TBR) && defined(USE_TBR)
+#if defined(HAVE_TBR)
   CURLcode ret = rb_thread_blocking_region(curl_easy_perform, curl, RUBY_UBF_IO, 0);
 #else
   CURLcode ret = curl_easy_perform(curl);


### PR DESCRIPTION
If patron is installed in a Ruby 1.9 environment, it makes sense to use the thread blocking region semantics. This allows long running requests to proceed _without_ blocking the entire Ruby virtual machine.

I attempted to find out a way to pass the USE_TBR flag to the gem during installation (gem install patron -- cppflags="-DUSE_TBR") but with little success. If there is a way to set USE_TBR during installation, please let me know.
