### PR TITLE
Allow Session.base_url to be overriden for specific requests

### DIFF
--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -210,14 +210,15 @@ module Patron
       req.upload_data            = options[:data]
       req.file_name              = options[:file]
 
-      url = self.base_url.to_s + url.to_s
-      uri = URI.parse(url)
+      base_url = self.base_url.to_s
+      url = url.to_s
+      raise ArgumentError, "Empty URL" if base_url.empty? && url.empty?
+      uri = URI.join(base_url, url)
       query = uri.query.to_s.split('&')
       query += options[:query].is_a?(Hash) ? Util.build_query_pairs_from_hash(options[:query]) : options[:query].to_s.split('&')
       uri.query = query.join('&')
       uri.query = nil if uri.query.empty?
       url = uri.to_s
-      raise ArgumentError, "Empty URL" if url.empty?
       req.url = url
 
       handle_request(req)

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -56,6 +56,11 @@ describe Patron::Session do
     body.request_method.should == "GET"
   end
 
+  it 'should ignore #base_url when a full URL is provided' do
+    @session.base_url = "http://example.com:123"
+    lambda { @session.get("http://localhost:9001/test") }.should_not raise_error(URI::InvalidURIError)
+  end
+
   it "should download content with :get and a file path" do
     tmpfile = "/tmp/patron_test.yaml"
     response = @session.get_file "/test", tmpfile


### PR DESCRIPTION
Uses URI.join to put together the base_url and the request url. Under the
hood, this does the right thing:

```
URI.join("http://example.com:123", "http://foo.example.com:1234/foo/bar").to_s
#=> "http://foo.example.com:1234/foo/bar"

URI.join("http://example.com:123", "/foo/bar").to_s
#=> "http://example.com:123/foo/bar"
```
