### PR TITLE
Fix Patron.version

### DIFF
--- a/lib/patron.rb
+++ b/lib/patron.rb
@@ -28,6 +28,7 @@ cwd = Pathname(__FILE__).dirname
 $:.unshift(cwd.to_s) unless $:.include?(cwd.to_s) || $:.include?(cwd.expand_path.to_s)
 
 require 'patron/session'
+require 'patron/version'
 
 module Patron #:nodoc:
   # Returns the version number of the Patron library as a string


### PR DESCRIPTION
Patron.version currently raises an uninitialized constant exception because of a missing require:

```
> Patron.version
NameError: uninitialized constant Patron::VERSION 
from /export/chk/patron/lib/patron.rb:36:in `version'
```

This fixes it.
