### PR TITLE
Adding Support for setting default headers on a Session

### DIFF
--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -59,7 +59,7 @@ module Patron
     attr_accessor :proxy_type
 
     # Standard set of headers that are used in all requests.
-    attr_reader :headers
+    attr_accessor :headers
 
     # Set the authentication type for the request.
     # @see Patron::Request#auth_type

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -84,6 +84,13 @@ describe Patron::Session do
     body.header["user-agent"].should == ["PatronTest"]
   end
 
+  it "should include default headers in a request, if they were defined" do
+    @session.headers = {"User-Agent" => "PatronTest"}
+    response = @session.get("/test")
+    body = YAML::load(response.body)
+    body.header["user-agent"].should == ["PatronTest"]
+  end
+
   it "should merge custom headers with session headers" do
     @session.headers["X-Test"] = "Testing"
     response = @session.get("/test", {"User-Agent" => "PatronTest"})


### PR DESCRIPTION
Fairly small change that allows for setting the headers on a Session. 

My use case:

All my Patron calls hit a specific REST API and need to have a specific set of headers (application/json and some others), and passing them in every call is a lot of duplication when I could just set them in the session itself. 
