### PR TITLE
Added support for sending data with delete requests

### DIFF
--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -141,6 +141,8 @@ module Patron
     end
 
     # As #get but sends an HTTP DELETE request.
+    # Notice: this method doesn't accept any +data+ argument: if you need to send data with
+    # a delete request, please, use the #request method.
     def delete(url, headers = {})
       request(:delete, url, headers)
     end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -166,6 +166,14 @@ describe Patron::Session do
     body.header['content-length'].should == [data.size.to_s]
   end
 
+  it "should upload data with :delete" do
+    data = "upload data"
+    response = @session.request(:delete, "/test", {}, :data => data)
+    body = YAML::load(response.body)
+    body.request_method.should == "DELETE"
+    body.header['content-length'].should == [data.size.to_s]
+  end
+
   it "should raise when no data is provided to :put" do
     lambda { @session.put("/test", nil) }.should raise_error(ArgumentError)
   end


### PR DESCRIPTION
Unusual, but needed by elasticsearch for the delete by query API. 

(see http://www.elasticsearch.org/guide/reference/api/delete-by-query/)
