### PR TITLE
make insecure on Patron::Session work again

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -493,7 +493,7 @@ static void set_options_from_request(VALUE self, VALUE request) {
   insecure = rb_iv_get(request, "@insecure");
   if(!NIL_P(insecure)) {
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
   }
 
   cacert = rb_iv_get(request, "@cacert");


### PR DESCRIPTION
cURL 7.28.1 removed support for value 1 on CURLOPT_SSL_VERIFYHOST, so we must
set to 0 to ignore certificate CN mismatches
