### PR TITLE
Patch request action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    patron (0.4.18)
+    patron (0.4.19)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.3)
     rake (0.9.2.2)

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -354,9 +354,9 @@ static void set_options_from_request(VALUE self, VALUE request) {
     rb_hash_foreach(headers, each_http_header, self);
   }
 
+  action = SYM2ID(action_name);
 
-  action = rb_to_id(action_name);
-  if (action == rb_intern("GET")) {
+  if (action == rb_intern("get")) {
     VALUE data = rb_iv_get(request, "@upload_data");
     VALUE download_file = rb_iv_get(request, "@file_name");
 
@@ -376,7 +376,7 @@ static void set_options_from_request(VALUE self, VALUE request) {
     } else {
       state->download_file = NULL;
     }
-  } else if (action == rb_intern("POST") || action == rb_intern("PUT")) {
+  } else if (action == rb_intern("post") || action == rb_intern("put")) {
     VALUE data = rb_iv_get(request, "@upload_data");
     VALUE filename = rb_iv_get(request, "@file_name");
     VALUE multipart = rb_iv_get(request, "@multipart");
@@ -386,7 +386,7 @@ static void set_options_from_request(VALUE self, VALUE request) {
 
       state->upload_buf = StringValuePtr(data);
 
-      if (action == rb_intern("POST")) {
+      if (action == rb_intern("post")) {
         curl_easy_setopt(curl, CURLOPT_POST, 1);
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, state->upload_buf);
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, len);
@@ -401,14 +401,14 @@ static void set_options_from_request(VALUE self, VALUE request) {
 
       curl_easy_setopt(curl, CURLOPT_UPLOAD, 1);
 
-      if (action == rb_intern("POST")) {
+      if (action == rb_intern("post")) {
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
       }
 
       state->upload_file = open_file(filename, "rb");
       curl_easy_setopt(curl, CURLOPT_READDATA, state->upload_file);
     } else if (!NIL_P(multipart)) {
-      if (action == rb_intern("POST")) {
+      if (action == rb_intern("post")) {
         if(!NIL_P(data) && !NIL_P(filename)) {
           if (rb_type(data) == T_HASH && rb_type(filename) == T_HASH) {
             rb_hash_foreach(data, formadd_values, self);
@@ -426,7 +426,7 @@ static void set_options_from_request(VALUE self, VALUE request) {
     }
 
   // support for data passed with a DELETE request (e.g.: used by elasticsearch)
-  } else if (action == rb_intern("DELETE")) {
+  } else if (action == rb_intern("delete")) {
       VALUE data = rb_iv_get(request, "@upload_data");
 
       if (!NIL_P(data)) {
@@ -438,9 +438,10 @@ static void set_options_from_request(VALUE self, VALUE request) {
       }
       curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
 
-  } else if (action == rb_intern("HEAD")) {
+  } else if (action == rb_intern("head")) {
     curl_easy_setopt(curl, CURLOPT_NOBODY, 1);
   } else {
+    VALUE action_name = rb_funcall(request, rb_intern("action_name"), 0);
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, StringValuePtr(action_name));
   }
 

--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -35,7 +35,7 @@ module Patron
     VALID_ACTIONS = %w[GET PUT POST DELETE HEAD COPY]
 
     def initialize
-      @action = 'GET'
+      @action = :get
       @headers = {}
       @timeout = 0
       @connect_timeout = 0
@@ -92,7 +92,7 @@ module Patron
       if !VALID_ACTIONS.include?(action.to_s.upcase)
         raise ArgumentError, "Action must be one of #{VALID_ACTIONS.join(', ')}"
       end
-      @action = action
+      @action = action.downcase.to_sym
     end
 
     def timeout=(new_timeout)
@@ -138,6 +138,10 @@ module Patron
     def credentials
       return nil if username.nil? || password.nil?
       "#{username}:#{password}"
+    end
+
+    def action_name
+      @action.to_s.upcase
     end
 
     def eql?(request)


### PR DESCRIPTION
Commit 716d483 intended to allow upper and lower case strings as well symbols, but then actually stored the action as an uppercase string. This breaks dependencies of other gems that expect a symbol from patron (e.g. Webmock). This commit continues to allow case-insensitive strings, but reverts to assigning the action as a ruby symbol.
