### PR TITLE
Build request

### DIFF
--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -201,6 +201,7 @@ module Patron
       handle_request(req)
     end
 
+    # Build a request object that can be used in +handle_request+
     def build_request(action, url, headers, options = {})
       # If the Expect header isn't set uploads are really slow
       headers['Expect'] ||= ''


### PR DESCRIPTION
This adds a `#build_request` method to `Patron::Session` that does all the stuff that `#request` would do.  It has the same signature.

This doesn't change the public API very much, beyond adding the new optional method.
