### PR TITLE
Adds accessor settings on instantiation via block or hash.

### DIFF
--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -91,7 +91,7 @@ module Patron
 
       # Allows accessors to be set via constructor hash. Ex:  {:base_url => 'www.home.com'}
       args.each do |attribute, value|
-        self.send("#{attribute}=", value)
+        send("#{attribute}=", value)
       end
 
       # Allows accessors to be set via block.

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -87,12 +87,23 @@ module Patron
     private :handle_request, :enable_cookie_session, :set_debug_file
 
     # Create a new Session object.
-    def initialize
-      @headers = {}
-      @timeout = 5
-      @connect_timeout = 1
-      @max_redirects = 5
-      @auth_type = :basic
+    def initialize(args = {}, &block)
+
+      # Allows accessor args to be set via constructor hash. Ex:  {:base_url => 'www.home.com'}
+      args.each do |attribute, value|
+        self.send("#{attribute}=", value)
+      end
+
+      # Allows accessor args to be set via block.
+      if block_given?
+        yield self
+      end
+
+      @headers ||= {}
+      @timeout ||= 5
+      @connect_timeout ||= 1
+      @max_redirects ||= 5
+      @auth_type ||= :basic
     end
 
     # Turn on cookie handling for this session, storing them in memory by

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -89,12 +89,12 @@ module Patron
     # Create a new Session object.
     def initialize(args = {}, &block)
 
-      # Allows accessor args to be set via constructor hash. Ex:  {:base_url => 'www.home.com'}
+      # Allows accessors to be set via constructor hash. Ex:  {:base_url => 'www.home.com'}
       args.each do |attribute, value|
         self.send("#{attribute}=", value)
       end
 
-      # Allows accessor args to be set via block.
+      # Allows accessors to be set via block.
       if block_given?
         yield self
       end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -322,6 +322,73 @@ describe Patron::Session do
     "Basic " + Base64.encode64("#{user}:#{passwd}").strip
   end
 
+  describe 'when instantiating with hash arguments' do
+
+    let(:args) { {
+        :timeout => 10,
+        :base_url => 'http://localhost:9001',
+        :headers => {'User-Agent' => 'myapp/1.0'}
+    } }
+
+    let(:session) { Patron::Session.new(args) }
+
+    it 'sets the base_url' do
+      session.base_url.should == args[:base_url]
+    end
+
+    it 'sets timeout' do
+      session.timeout.should == args[:timeout]
+    end
+
+    it 'sets headers' do
+      session.headers.should == args[:headers]
+    end
+
+    context 'when given an incorrect accessor name' do
+      let(:args) { { :not_a_real_accessor => 'http://localhost:9001' }}
+      it 'raises no method error' do
+        expect { session }.to raise_error NoMethodError
+      end
+    end
+
+  end
+
+  describe 'when instantiating with a block' do
+    args = {
+        :timeout => 10,
+        :base_url => 'http://localhost:9001',
+        :headers => {'User-Agent' => 'myapp/1.0'}
+    }
+
+    session = Patron::Session.new do |patron|
+      patron.timeout = args[:timeout]
+      patron.base_url = args[:base_url]
+      patron.headers =  args[:headers]
+    end
+
+    it 'sets the base_url' do
+      session.base_url.should == args[:base_url]
+    end
+
+    it 'sets timeout' do
+      session.timeout.should == args[:timeout]
+    end
+
+    it 'sets headers' do
+      session.headers.should == args[:headers]
+    end
+
+    context 'when given an incorrect accessor name' do
+      it 'raises no method error' do
+        expect {
+          Patron::Session.new do |patron|
+            patron.timeoutttt = args[:timeout]
+          end
+        }.to raise_error NoMethodError
+      end
+    end
+  end
+
   # ------------------------------------------------------------------------
   describe 'when debug is enabled' do
     it 'it should not clobber stderr' do


### PR DESCRIPTION
#### Changes

Allows ```Patron::Session``` to set accessors via constructor hash or block.  

Examples:

***via hash***

```ruby
session = Patron::Session({ :timeout => 20,
                            :base_url => 'http://localhost:9000',
                            :headers => {'User-Agent' => 'myapp/1.0'} } )

session.timeout # => 20
session.base_url # => "http://localhost:9000"
session.headers # => {"User-Agent"=>"myapp/1.0"}
```

***via block***

```ruby
session = Patron::Session.new do |patron|
  patron.timeout = 20
  patron.base_url = 'http://localhost:9000'
  patron.headers = {'User-Agent' => 'myapp/1.0'}
end

session.timeout # => 20
session.base_url # => "http://localhost:9000"
session.headers # => {"User-Agent"=>"myapp/1.0"}
```



#### New tests 

```bash
rspec spec/session_spec.rb
```