### PR TITLE
Use rb_thread_call_without_gvl if possible

### DIFF
--- a/ext/patron/extconf.rb
+++ b/ext/patron/extconf.rb
@@ -44,6 +44,8 @@ if CONFIG['CC'] =~ /gcc/
 end
 
 $defs.push("-DUSE_TBR")
-$defs.push("-DHAVE_TBR") if have_func('rb_thread_blocking_region')
+$defs.push("-DHAVE_THREAD_H") if have_header('ruby/thread.h')
+$defs.push("-DHAVE_TBR") if have_func('rb_thread_blocking_region', 'ruby.h')
+$defs.push("-DHAVE_TCWOGVL") if have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')
 
 create_makefile 'patron/session_ext'


### PR DESCRIPTION
`rb_thread_blocking_region` is deprecated since 2.0 and completely removed
in 2.2. `rb_thread_call_without_gvl` should be used instead on all rubies
that already have it.

Without this on Ruby 2.2 Patron blocks GVL on every request.