### PR TITLE
Fix incorrect list element comparator.

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -112,7 +112,7 @@ struct curl_state_list {
   struct curl_state_list  *next;
 };
 
-#define CS_LIST_COMPARATOR(p, _state_) (p->state == _state_)
+#define CS_LIST_COMPARATOR(p, _state_) (p->state - _state_)
 
 static struct curl_state_list *cs_list = NULL;
 
@@ -131,9 +131,9 @@ static void cs_list_remove(struct curl_state *state) {
   struct curl_state_list *item = NULL;
 
   assert(state != NULL);
-  SGLIB_LIST_FIND_MEMBER(struct curl_state_list, cs_list, state, CS_LIST_COMPARATOR, next, item);
+
+  SGLIB_LIST_DELETE_IF_MEMBER(struct curl_state_list, cs_list, state, CS_LIST_COMPARATOR, next, item);
   if (item) {
-    SGLIB_LIST_DELETE(struct curl_state_list, cs_list, item, next);
     ruby_xfree(item);
   }
 }


### PR DESCRIPTION
`cs_list` elements was being comparing incorrectly.
C operator `==` returns 1 on equal elements but SGLIB wants a zero.
As a consequence `ruby_xfree` was being calling on memory regions that are in
use. It caused random segfaults when using Patron.

Also this patch optimizes list element deletion: there is a convenient
SGLIB macro `SGLIB_LIST_DELETE_IF_MEMBER` so there's no need to go
through list twice.

This helped me to get rid of frequent segfaults on my machine (tested on rubies 1.9.3 - 2.2.0). Maybe It's related to #72 but I'm not sure.