### PR TITLE
Fix base url concatenation if base_url is empty

### DIFF
--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -245,7 +245,7 @@ module Patron
         base_url = self.base_url.to_s
         url = url.to_s
         raise ArgumentError, "Empty URL" if base_url.empty? && url.empty?
-        uri = URI.parse(File.join(base_url, url))
+        uri = URI.parse(base_url.empty? ? url : File.join(base_url, url))
         query = uri.query.to_s.split('&')
         query += options[:query].is_a?(Hash) ? Util.build_query_pairs_from_hash(options[:query]) : options[:query].to_s.split('&')
         uri.query = query.join('&')


### PR DESCRIPTION
If no base_url is given d34837c0d1bac643b05e9f2bc8618006c2b0f932 produces incorrect URIs. 

Example

```ruby
# base_url is "" because of nil.to_s
URI.parse(File.join("", "http://localhost")) # => #<URI::Generic /http://localhost>
```

Easiest way to fix this is to add a conditional for the case `base_url.empty?`.