### PR TITLE
Optimize Response#parse_headers

### DIFF
--- a/lib/patron/response.rb
+++ b/lib/patron/response.rb
@@ -89,16 +89,18 @@ module Patron
 
       @status_line = lines.shift
 
-      lines.each do |header|
-        parts = header.split(':', 2)
-        unless parts.empty?
-          parts[1].strip! unless parts[1].nil?
-          if @headers.has_key?(parts[0])
-            @headers[parts[0]] = [@headers[parts[0]]] unless @headers[parts[0]].kind_of? Array
-            @headers[parts[0]] << parts[1]
-          else
-            @headers[parts[0]] = parts[1]
-          end
+      lines.each do |line|
+        break if line.empty?
+
+        hdr, val = line.split(":", 2)
+
+        val.strip! unless val.nil?
+
+        if @headers.key?(hdr)
+          @headers[hdr] = [@headers[hdr]] unless @headers[hdr].kind_of? Array
+          @headers[hdr] << val
+        else
+          @headers[hdr] = val
         end
       end
     end

--- a/lib/patron/response.rb
+++ b/lib/patron/response.rb
@@ -85,19 +85,19 @@ module Patron
     def parse_headers(header_data)
       @headers = {}
 
-      header_data.split("\r\n").each do |header|
-        if header =~ %r|^HTTP/1.[01]|
-          @status_line = header.strip
-        else
-          parts = header.split(':', 2)
-          unless parts.empty?
-            parts[1].strip! unless parts[1].nil?
-            if @headers.has_key?(parts[0])
-              @headers[parts[0]] = [@headers[parts[0]]] unless @headers[parts[0]].kind_of? Array
-              @headers[parts[0]] << parts[1]
-            else
-              @headers[parts[0]] = parts[1]
-            end
+      lines = header_data.split("\r\n")
+
+      @status_line = lines.shift
+
+      lines.each do |header|
+        parts = header.split(':', 2)
+        unless parts.empty?
+          parts[1].strip! unless parts[1].nil?
+          if @headers.has_key?(parts[0])
+            @headers[parts[0]] = [@headers[parts[0]]] unless @headers[parts[0]].kind_of? Array
+            @headers[parts[0]] << parts[1]
+          else
+            @headers[parts[0]] = parts[1]
           end
         end
       end

--- a/lib/patron/response.rb
+++ b/lib/patron/response.rb
@@ -85,7 +85,7 @@ module Patron
     def parse_headers(header_data)
       @headers = {}
 
-      header_data.split(/\r\n/).each do |header|
+      header_data.split("\r\n").each do |header|
         if header =~ %r|^HTTP/1.[01]|
           @status_line = header.strip
         else


### PR DESCRIPTION
The current version of `Patron::Response#parse_headers` uses regular expressions in two places where they aren't necessary. The first is when splitting `header_data` by CRLF. Changing `split(/\r\n/)` for `split("\r\n")` shows a ten percent improvement when running benchmarks using [`benchmark-ips`](https://github.com/evanphx/benchmark-ips):

```
Calculating -------------------------------------
            original     6.530k i/100ms
           optimized     8.301k i/100ms
-------------------------------------------------
            original     77.486k (±11.8%) i/s -    385.270k
           optimized     86.069k (±17.6%) i/s -    415.050k

Comparison:
           optimized:    86068.7 i/s
           original:    77485.6 i/s - 1.11x slower
```

The second change is that on each iteration the first operation is to check if the line starts with `HTTP/1.[01]` to set `@status_line`. According to the HTTP specification the first line of a response is the status line, thus the proposed change is to rely on the specification and assign the first line of `header_data` to `@status_line`. Applying this change in top of the previous one shows that the original implementantion is now 1.57 times slower:

```
Calculating -------------------------------------
            original     7.606k i/100ms
           optimized    11.805k i/100ms
-------------------------------------------------
            original     79.366k (±13.3%) i/s -    783.418k
           optimized    124.498k (±30.1%) i/s -    944.400k

Comparison:
           optimized:   124498.1 i/s
           original:    79365.5 i/s - 1.57x slower
```

Last change is composed of two things: the first relies on the fact that `parts = header.split(":", 2)` will only return an empty array if the line doesn't have a `:` character in it, that is, it doesn't have a header; in that case we're finishing the loop early:

```
$ pry
[1] pry(main)> "lorem: ipsum".split(":", 2)
=> ["lorem", " ipsum"]
[2] pry(main)> "lorem: ".split(":", 2)
=> ["lorem", " "]
[3] pry(main)> ": ipsum".split(":", 2)
=> ["", " ipsum"]
[4] pry(main)> ": ".split(":", 2)
=> ["", " "]
[5] pry(main)> "".split(":", 2)
=> []
```

The second part of this third change is just aesthetics: instead of referring to `parts[0]` and `parts[1]`, assign the values to `hdr` and `val` variables.

These three changes combined give an overall improvement of almost 70% when parsing headers:

```
Calculating -------------------------------------
            original     7.276k i/100ms
           optimized    12.544k i/100ms
-------------------------------------------------
            original     84.107k (± 7.6%) i/s -    836.740k
           optimized    144.641k (±15.1%) i/s -      1.392M

Comparison:
           optimized:   144641.1 i/s
           original:    84107.0 i/s - 1.72x slower
```

In case you're interested, this is the benchmark I've been using for these changes:

```ruby
#! /usr/bin/env ruby

require "pry"
require "benchmark/ips"

header_data = "HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=UTF-8\r\nContent-Length: 327\r\n\r\n"

def original(header_data)
  @headers = {}

  header_data.split(/\r\n/).each do |header|
    if header =~ %r|^HTTP/1.[01]|
      @status_line = header.strip
    else
      parts = header.split(':', 2)
      unless parts.empty?
        parts[1].strip! unless parts[1].nil?
        if @headers.has_key?(parts[0])
          @headers[parts[0]] = [@headers[parts[0]]] unless @headers[parts[0]].kind_of? Array
          @headers[parts[0]] << parts[1]
        else
          @headers[parts[0]] = parts[1]
        end
      end
    end
  end
end

def optimized(header_data)
  @headers = {}

  lines = header_data.split("\r\n")

  @status_line = lines.shift

  lines.each do |header|
    break if header.empty?

    hdr, val = header.split(":", 2)

    val.strip! unless val.nil?

    if @headers.key?(hdr)
      @headers[hdr] = [@headers[hdr]] unless @headers[hdr].kind_of? Array
      @headers[hdr] << val
    else
      @headers[hdr] = val
    end
  end
end

Benchmark.ips(Integer(ARGV.first || 10)) do |r|
  r.report("original") { original(header_data) }

  r.report("optimized") { optimized(header_data) }

  r.compare!
end

```

I've been using these changes on a project at my company and we haven't encountered any problems with it.
