### PR TITLE
Don't fail with invalid charset names

### DIFF
--- a/lib/patron/response.rb
+++ b/lib/patron/response.rb
@@ -68,11 +68,18 @@ module Patron
     def determine_charset(header_data, body)
       header_data.match(charset_regex) || (body && body.match(charset_regex))
 
-      $1
+      charset = $1
+      validate_charset(charset) ? charset : nil
     end
 
     def charset_regex
       /(?:charset|encoding)="?([a-z0-9-]+)"?/i
+    end
+
+    def validate_charset(charset)
+      charset && Encoding.find(charset) && true
+    rescue ArgumentError
+      false
     end
 
     def convert_to_default_encoding!(str)


### PR DESCRIPTION
Currently patron throws an exception 
```
ArgumentError: unknown encoding name - utf8
```
whenever it encounters response with unknown charset. In my case it fails for charset *utf8* (valid one is *utf-8*)

This PR fixes this problem.