### PR TITLE
Ensure the form data is freed in cleanup

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -647,6 +647,10 @@ static VALUE cleanup(VALUE self) {
     state->upload_file = NULL;
   }
 
+  if (state->post) {
+    curl_formfree(state->post);
+  }
+
   state->upload_buf = NULL;
 
   return Qnil;


### PR DESCRIPTION
The curl docs on https://curl.haxx.se/libcurl/c/curl_formadd.html
say that after use the form list should be freed manually