### PR TITLE
RFC: Add the ability to override the Response class by subclassing Session

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -537,7 +537,8 @@ static VALUE create_response(VALUE self, CURL* curl, VALUE header_buffer, VALUE 
   char* effective_url = NULL;
   long code = 0;
   long count = 0;
-
+  VALUE responseKlass = Qnil;
+  
   curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &effective_url);
   args[0] = rb_str_new2(effective_url);
 
@@ -550,8 +551,9 @@ static VALUE create_response(VALUE self, CURL* curl, VALUE header_buffer, VALUE 
   args[3] = header_buffer;
   args[4] = body_buffer;
   args[5] = rb_iv_get(self, "@default_response_charset");
-
-  return rb_class_new_instance(6, args, rb_const_get(mPatron, rb_intern("Response")));
+  
+  responseKlass = rb_funcall(self, rb_intern("response_class"), 0);
+  return rb_class_new_instance(6, args, responseKlass);
 }
 
 /* Raise an exception based on the Curl error code. */

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -215,7 +215,19 @@ module Patron
       req = build_request(action, url, headers, options)
       handle_request(req)
     end
-
+    
+    # Returns the class that will be used to build a Response
+    # from a Curl call.
+    #
+    # Primarily useful if you need a very lightweight Response
+    # object that does not have to perform all the parsing of
+    # various headers/status codes. The method must return
+    # a module that supports the same interface for +new+
+    # as ++Patron::Response++
+    def response_class
+      ::Patron::Response
+    end
+    
     # Build a request object that can be used in +handle_request+
     def build_request(action, url, headers, options = {})
       # If the Expect header isn't set uploads are really slow

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -333,6 +333,31 @@ describe Patron::Session do
     "Basic " + Base64.encode64("#{user}:#{passwd}").strip
   end
 
+  describe 'when using a subclass with a custom Response' do
+    
+    class CustomResponse
+      attr_reader :constructor_args
+      def initialize(*constructor_args)
+        @constructor_args = constructor_args
+      end
+    end
+    
+    class CustomizedSession < Patron::Session
+      def response_class
+        CustomResponse
+      end
+    end
+    
+    it 'instantiates the customized response object' do
+      @session = CustomizedSession.new
+      @session.base_url = "http://localhost:9001"
+      response = @session.request(:get, "/test", {}, :query => {:foo => "bar"})
+      
+      expect(response).to be_kind_of(CustomResponse)
+      expect(response.constructor_args.length).to eq(6)
+    end
+  end
+  
   describe 'when instantiating with hash arguments' do
 
     let(:args) { {


### PR DESCRIPTION
When running repetitive requests (tremendous amounts of repetitive requests in fact), you might want to skip charset detection and header parsing for performance. That is very difficult to do if the class lookup for Response happens at the C level. Therefore, it might be a good idea to use dynamic lookup to figure out the response class. If you subclass Session and override the `response_class` you can then use an optimised version of a Response that, for instance, quickly grabs the status code that you got and moves on.

Adds one method call per request-response cycle and one stack cruby ref, so should be gentle performance-wise.