### PR TITLE
Cast request body to string when uploading

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -367,6 +367,7 @@ static void set_options_from_request(VALUE self, VALUE request) {
 
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
     if (!NIL_P(data)) {
+      data = rb_funcall(data, rb_intern("to_s"), 0);
       long len = RSTRING_LEN(data);
       state->upload_buf = StringValuePtr(data);
       curl_easy_setopt(curl, CURLOPT_UPLOAD, 1);
@@ -387,8 +388,8 @@ static void set_options_from_request(VALUE self, VALUE request) {
     VALUE multipart = rb_iv_get(request, "@multipart");
 
     if (!NIL_P(data) && NIL_P(multipart)) {
+      data = rb_funcall(data, rb_intern("to_s"), 0);
       long len = RSTRING_LEN(data);
-
       state->upload_buf = StringValuePtr(data);
 
       if (action == rb_intern("post")) {

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -168,7 +168,14 @@ describe Patron::Session do
     expect(body.request_method).to be == "GET"
     expect(body.header['content-length']).to be == [data.size.to_s]
   end
-
+  
+  it "should call to_s on the data being uploaded via GET if it is not already a String" do
+    data = 12345
+    response = @session.request(:get, "/test", {}, :data => data)
+    body = YAML::load(response.body)
+    expect(body.request_method).to be == "GET"
+  end
+  
   it "should upload data with :put" do
     data = "upload data"
     response = @session.put("/test", data)
@@ -204,7 +211,14 @@ describe Patron::Session do
     body = YAML::load(response.body)
     expect(body.header['transfer-encoding'].first).to be == "chunked"
   end
-
+  
+  it "should call to_s on the data being uploaded via POST if it is not already a String" do
+    data = 12345
+    response = @session.post("/testpost", data)
+    body = YAML::load(response.body)
+    expect(body['body']).to eq("12345")
+  end
+  
   it "should upload data with :post" do
     data = "upload data"
     response = @session.post("/test", data)


### PR DESCRIPTION
Replace the data object with return value of its to_s
before performing the request, since string pointers on
non-String VALUE types does not perform any checks but
crashes instead.

Fixes #65