### PR TITLE
Use CURL URL escaping instead of cgi.rb

### DIFF
--- a/lib/patron/util.rb
+++ b/lib/patron/util.rb
@@ -23,8 +23,6 @@
 ##
 ## -------------------------------------------------------------------
 
-require 'cgi'
-
 module Patron
   module Util
     extend self
@@ -34,7 +32,7 @@ module Patron
       recursive = Proc.new do |h, prefix|
         h.each_pair do |k,v|
           key = prefix == '' ? k : "#{prefix}[#{k}]"
-          v = CGI::escape(v.to_s) if escape_values
+          v = Patron::Session.escape(v.to_s) if escape_values
           v.is_a?(Hash) ? recursive.call(v, key) : pairs << "#{key}=#{v}"
         end
       end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -38,14 +38,30 @@ describe Patron::Session do
     @session.force_ipv4 = true
     expect { @session.get("/test") }.to_not raise_error
   end
-
-  it "should escape and unescape strings symetrically" do
-    string = "foo~bar baz/"
-    escaped = @session.escape(string)
-    unescaped = @session.unescape(escaped)
-    expect(unescaped).to be == string
+  
+  describe '.escape and #escape' do
+    it 'makes escape() and unescape() available on the class' do
+      string = "foo~bar baz/"
+      escaped = described_class.escape(string)
+      unescaped = described_class.unescape(escaped)
+      expect(unescaped).to be == string
+    end
+    
+    it "should escape and unescape strings symetrically" do
+      string = "foo~bar baz/"
+      escaped = @session.escape(string)
+      unescaped = @session.unescape(escaped)
+      expect(unescaped).to be == string
+    end
+  
+    it "should make e and unescape strings symetrically" do
+      string = "foo~bar baz/"
+      escaped = @session.escape(string)
+      unescaped = @session.unescape(escaped)
+      expect(unescaped).to be == string
+    end
   end
-
+  
   it "should raise an error when passed an invalid action" do
     expect { @session.request(:bogus, "/test", {}) }.to raise_error(ArgumentError)
   end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -26,6 +26,7 @@ require File.expand_path("./spec") + '/spec_helper.rb'
 describe Patron::Util do
 
   describe :build_query_pairs_from_hash do
+    
     it "correctly serializes a simple hash" do
       hash = {:foo => "bar", "baz" => 42}
       array = Patron::Util.build_query_pairs_from_hash(hash)
@@ -33,6 +34,7 @@ describe Patron::Util do
       expect(array).to include("foo=bar")
       expect(array).to include("baz=42")
     end
+    
     it "correctly serializes a more complex hash" do
       hash = {
         :foo => "bar",


### PR DESCRIPTION
By extension, make escape() and unescape()
available on the Session class so that Util
does not have to have access to the Session
object when performing escapes/unescapes.