### PR TITLE
Add automatic Content-Encoding support

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -347,6 +347,7 @@ static void set_options_from_request(VALUE self, VALUE request) {
   VALUE ssl_version           = Qnil;
   VALUE buffer_size           = Qnil;
   VALUE action_name           = rb_iv_get(request, "@action");
+  VALUE a_c_encoding          = rb_iv_get(request, "@automatic_content_encoding");
 
   headers = rb_iv_get(request, "@headers");
   if (!NIL_P(headers)) {
@@ -454,6 +455,12 @@ static void set_options_from_request(VALUE self, VALUE request) {
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, state->headers);
   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, state->error_buf);
 
+  // Enable automatic content-encoding support via gzip/deflate if set in the request,
+  // see https://curl.haxx.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html
+  if(RTEST(a_c_encoding)) {
+    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+  }
+  
   url = rb_iv_get(request, "@url");
   if (NIL_P(url)) {
     rb_raise(rb_eArgError, "Must provide a URL");

--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -46,12 +46,12 @@ module Patron
       :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
       :ignore_content_length, :multipart, :action, :timeout, :connect_timeout,
       :max_redirects, :headers, :auth_type, :upload_data, :buffer_size, :cacert,
-      :ssl_version, :force_ipv4
+      :ssl_version, :automatic_content_encoding, :force_ipv4
     ]
 
     WRITER_VARS = [
       :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
-      :ignore_content_length, :multipart, :cacert, :ssl_version, :force_ipv4
+      :ignore_content_length, :multipart, :cacert, :ssl_version, :automatic_content_encoding, :force_ipv4
     ]
 
     attr_reader *READER_VARS

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -87,6 +87,9 @@ module Patron
     # Force curl to use IPv4
     attr_accessor :force_ipv4
 
+    # Support automatic Content-Encoding decompression and set liberal Accept-Encoding headers
+    attr_accessor :automatic_content_encoding
+    
     private :handle_request, :enable_cookie_session, :set_debug_file
 
     # Create a new Session object.
@@ -236,6 +239,7 @@ module Patron
       Request.new.tap do |req|
         req.action                 = action
         req.headers                = self.headers.merge headers
+        req.automatic_content_encoding = options.fetch :automatic_content_encoding, self.automatic_content_encoding
         req.timeout                = options.fetch :timeout,               self.timeout
         req.connect_timeout        = options.fetch :connect_timeout,       self.connect_timeout
         req.force_ipv4             = options.fetch :force_ipv4,            self.force_ipv4

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -329,6 +329,17 @@ describe Patron::Session do
     expect(body.request_method).to be == "GET"
   end
 
+  it "should automatically decompress using Content-Encoding if requested" do
+    @session.automatic_content_encoding = true
+    response = @session.get('/gzip-compressed')
+    
+    expect(response.headers['Content-Length']).to eq('125')
+    
+    body = response.body
+    expect(body).to match(/Some highly compressible data/)
+    expect(body.bytesize).to eq(29696)
+  end
+  
   it "should serialize query params and append them to the url" do
     response = @session.request(:get, "/test", {}, :query => {:foo => "bar"})
     request = YAML::load(response.body)


### PR DESCRIPTION
using the built-in CURL facilities. CURL will
automatically decode and decompress the response
when Session#automatic_content_encoding is
set to `true`.

Fixes #64