### PR TITLE
Fix cookie jar saving after request completion

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -637,7 +637,9 @@ static VALUE perform_request(VALUE self) {
     VALUE header_str = membuffer_to_rb_str(header_buffer);
     VALUE body_str = Qnil;
     if (!state->download_file) { body_str = membuffer_to_rb_str(body_buffer); }
-
+    
+    curl_easy_setopt(curl, CURLOPT_COOKIELIST, "FLUSH"); // Flush cookies to the cookie jar
+    
     return create_response(self, curl, header_str, body_str);
   } else {
     rb_raise(select_error(ret), "%s", state->error_buf);

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -288,6 +288,18 @@ describe Patron::Session do
     expect(body.header['authorization']).to be == [encode_authz("foo", "bar")]
   end
 
+  it "should store cookies across multiple requests" do
+    tf = Tempfile.new('cookiejar')
+    cookie_jar_path = tf.path
+    
+    @session.handle_cookies(cookie_jar_path)
+    response = @session.get("/setcookie").body
+    
+    cookie_jar_contents = tf.read
+    expect(cookie_jar_contents).not_to be_empty
+    expect(cookie_jar_contents).to include('Netscape HTTP Cookie File')
+  end
+  
   it "should handle cookies if set" do
     @session.handle_cookies
     response = @session.get("/setcookie").body


### PR DESCRIPTION
Previously the cookie jar would not be saved
even with a cookie jar path set.

Fixes #15