### PR TITLE
Add encoding pragma for testing on 1.9

### DIFF
--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding: UTF-8 -*-
+# Encoding pragma is needed for loading this test properly on Ruby < 2.0
+
 ## -------------------------------------------------------------------
 ##
 ## Copyright (c) 2009 Phillip Toland <phil.toland@gmail.com>


### PR DESCRIPTION
On 1.9, the file is not assumed to be UTF-8 by default,
so to test with UTF-8 literals the encoding pragma _is_
required.