### PR TITLE
Fix handling of literal PUT bodies larger than 31 byte long (no, really)

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -410,14 +410,15 @@ static void set_options_from_request(VALUE self, VALUE request) {
 
       if (action == rb_intern("post")) {
         curl_easy_setopt(curl, CURLOPT_POST, 1);
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, state->upload_buf);
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, len);
-      } else {
-        curl_easy_setopt(curl, CURLOPT_UPLOAD, 1);
-        curl_easy_setopt(curl, CURLOPT_READFUNCTION, &session_read_handler);
-        curl_easy_setopt(curl, CURLOPT_READDATA, &state->upload_buf);
-        curl_easy_setopt(curl, CURLOPT_INFILESIZE, len);
       }
+      curl_easy_setopt(curl, CURLOPT_POSTFIELDS, state->upload_buf);
+
+      #ifdef CURLOPT_POSTFIELDSIZE_LARGE
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)len);
+      #else
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (curl_off_t)len);
+      #endif
+
     } else if (!NIL_P(filename) && NIL_P(multipart)) {
       set_chunked_encoding(state);
 

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -195,7 +195,7 @@ describe Patron::Session do
   end
   
   it "should upload data with :put" do
-    data = "upload data"
+    data = SecureRandom.random_bytes(1024 * 24)
     response = @session.put("/test", data)
     body = YAML::load(response.body)
     expect(body.request_method).to be == "PUT"


### PR DESCRIPTION
Fix the issue with a timeout occurring when you try to send a literal string buffer as if it were a file. I think something is broken in the session_read_handler just by virtue of it using `strlen()` where binary bodies may be involved. Also, judging from the CURL docs it is really meant for files, or other situations where you fetch from an external source (like an upstream server).

Should resolve #12 