### PR TITLE
Make sure the state->post and stat-last pointers are cleared after curl_formfree()

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -669,6 +669,8 @@ static VALUE cleanup(VALUE self) {
 
   if (state->post) {
     curl_formfree(state->post);
+    state->post = NULL;
+    state->last = NULL;
   }
 
   state->upload_buf = NULL;


### PR DESCRIPTION
Fix for issue #119 

Make sure the state->post and stat-last pointers are cleared after
calling curl_formfree(). libcurl does not reset these pointers and they 
need to be cleared.