### PR TITLE
Explain the SSL segfaults on OSX and propose a solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.6.4
 
+* Explain a segfault with SSL in forked processes on OSX, document the way to avoid the issue
 * Fix segfault when attempting multiple post requests with multipart (#119)
 
 ### 0.6.3

--- a/ext/patron/extconf.rb
+++ b/ext/patron/extconf.rb
@@ -28,7 +28,10 @@ require 'rbconfig'
 
 dir_config('curl')
 
-if find_executable('curl-config')
+if curl_config_path = with_config('curl-config')
+  $CFLAGS << " #{`#{curl_config_path} --cflags`.strip}"
+  $LIBS << " #{`#{curl_config_path} --libs`.strip}"
+elsif find_executable('curl-config')
   $CFLAGS << " #{`curl-config --cflags`.strip}"
   $LIBS << " #{`curl-config --libs`.strip}"
 elsif !have_library('curl') or !have_header('curl/curl.h')


### PR DESCRIPTION
There is an issue with libCURL on OSX currently related to a bug (or a subtle behavior quirk) when forking is involved. This documents the issue, adds a test to see if it is present, and adds a compile-time flag to link curl from homebrew explicitly (because Homebrew does not put it in the default $PATH, for reasons).

I am afraid this is the best we can do at the moment. The problem is under investigation upstream.