### PR TITLE
[WIP] Rework charset coercion

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--markup markdown

--- a/lib/patron/error.rb
+++ b/lib/patron/error.rb
@@ -31,29 +31,38 @@ module Patron
 
   # Gets raised when the URL passed to Patron used a protocol that it does not support.
   # This most likely the result of a misspelled protocol string.
-  class UnsupportedProtocol   < Error; end
+  class UnsupportedProtocol    < Error; end
 
   # Gets raised when a request is attempted with an unsupported SSL version.
-  class UnsupportedSSLVersion < Error; end
+  class UnsupportedSSLVersion  < Error; end
 
   # Gets raised when the URL was not properly formatted.
-  class URLFormatError        < Error; end
+  class URLFormatError         < Error; end
 
   # Gets raised when the remote host name could not be resolved.
-  class HostResolutionError   < Error; end
+  class HostResolutionError    < Error; end
 
   # Gets raised when failing to connect to the remote host.
-  class ConnectionFailed      < Error; end
+  class ConnectionFailed       < Error; end
 
   # Gets raised when the response was shorter or larger than expected.
   # This happens when the server first reports an expected transfer size,
   # and then delivers data that doesn't match the previously given size.
-  class PartialFileError      < Error; end
+  class PartialFileError       < Error; end
 
   # Gets raised on an operation timeout. The specified time-out period was reached.
-  class TimeoutError          < Error; end
+  class TimeoutError           < Error; end
 
   # Gets raised on too many redirects. When following redirects, Patron hit the maximum amount.
-  class TooManyRedirects      < Error; end
+  class TooManyRedirects       < Error; end
 
+  # Gets raised when the server specifies an encoding that could not be found, or has an invalid name,
+  # or when the server "lies" about the encoding of the response body (such as can be the case
+  # when the server specifies an encoding in `Content-Type`) which the HTML generator then overrides
+  # with a `meta` element.
+  class HeaderCharsetInvalid < Error; end
+  
+  # Gets raised when you try to use `decoded_body` but it can't
+  # be represented by your Ruby process's current internal encoding
+  class NonRepresentableBody < HeaderCharsetInvalid; end
 end

--- a/lib/patron/response.rb
+++ b/lib/patron/response.rb
@@ -28,6 +28,8 @@ module Patron
 
   # Represents the response from the HTTP server.
   class Response
+    include ResponseDecoding
+    
     # @return [String] the original URL used to perform the request (contains the final URL after redirects)
     attr_reader :url
 
@@ -40,14 +42,16 @@ module Patron
     # @return [Fixnum] how many redirects were followed when fulfilling this request
     attr_reader :redirect_count
 
-    # @return [String, nil] the response body, or nil if the response was written directly to a file
+    # @return [String, nil] the response body as a String encoded as `Encoding::BINARY` or
+    #           or `nil` if the response was written directly to a file
     attr_reader :body
-
+    
     # @return [Hash] the response headers. If there were multiple headers received for the same value
     #   (like "Cookie"), the header values will be within an Array under the key for the header, in order.
     attr_reader :headers
 
-    # @return [String] the recognized name of the charset for the response
+    # @return [String] the recognized name of the charset for the response. The name is not checked
+    #    to be a valid charset name, just stored. To check the charset for validity, use #body_decodable?
     attr_reader :charset
 
     # Overridden so that the output is shorter and there is no response body printed
@@ -56,50 +60,69 @@ module Patron
       "#<Patron::Response @status_line='#{@status_line}'>"
     end
 
-    def initialize(url, status, redirect_count, header_data, body, default_charset = nil)
-      # Don't let a response clear out the default charset, which would cause encoding to fail
-      default_charset = "ASCII-8BIT" unless default_charset
-      @url            = url
+    def initialize(url, status, redirect_count, raw_header_data, body, default_charset = nil)
+      @url            = url.force_encoding(Encoding::ASCII) # the URL is always an ASCII subset, _always_.
       @status         = status
       @redirect_count = redirect_count
-      @body           = body
+      @body           = body.force_encoding(Encoding::BINARY) if body
 
-      @charset        = determine_charset(header_data, body) || default_charset
-
-      [url, header_data].each do |attr|
-        convert_to_default_encoding!(attr)
-      end
-
+      header_data = decode_header_data(raw_header_data)
       parse_headers(header_data)
-      if @headers["Content-Type"] && @headers["Content-Type"][0, 5] == "text/"
-        convert_to_default_encoding!(@body)
-      end
+      @charset = charset_from_content_type
     end
 
-    private
-
-    def determine_charset(header_data, body)
-      header_data.match(charset_regex) || (body && body.match(charset_regex))
-
-      charset = $1
-      validate_charset(charset) ? charset : nil
+    # Returns the response body converted into the Ruby process internal encoding (the one set as `Encoding.default_internal`).
+    # As the response gets returned, the response body is not assumed to be in any encoding whatsoever - it will be explicitly
+    # set to `Encoding::BINARY` (as if you were reading a file in binary mode).
+    #
+    # When you call `decoded_body`, the method will
+    # look at the `Content-Type` response header, and check if that header specified a charset. If it did, the method will then
+    # check whether the specified charset is valid (whether it is possible to find a matching `Encoding` class in the VM).
+    # Once that succeeds, the method will check whether the response body _is_ in the encoding that the server said it is.
+    #
+    # This might not be the case - you can, for instance, easily serve an HTML document with a UTF-8 header (with the header
+    # being configured somewhere on the webserver level) and then have the actual HTML document override it with a
+    # `meta` element  or `charset` containing an overriding charset. However, parsing the response body is outside of scope for
+    # Patron, so if this situation happens (the server sets a charset in the header but this header does not match what the server
+    # actually sends in the body) you will get an exception stating this is a problem.
+    #
+    # The next step is actually converting the body to the internal Ruby encoding. That stage may raise an exception as well, if
+    # you are using an internal encoding which can't represent the response body faithfully. For example, if you run Ruby with
+    # a CJK internal encoding, and the response you are trying to decode uses Greek characters and is UTF-8, you are going to
+    # get an exception since it is impossible to coerce those characters to your internal encoding.
+    #
+    # @raise {Patron::HeaderCharsetInvalid} when the server supplied a wrong or incorrect charset, {Patron::NonRepresentableBody}
+    #    when unable to decode the body into the current process encoding.
+    # @return [String, nil]
+    def decoded_body
+      return unless @body
+      @decoded_body ||= decode_body(strict=true)
     end
-
-    def charset_regex
-      /(?:charset|encoding)="?([a-z0-9-]+)"?/i
+    
+    # Works the same as `decoded_body`, with one substantial difference: characters which can't be represented
+    # in your process' default encoding are going to be replaced with question marks. This can be used for raising
+    # errors when you receive responses which indicate errors on the server you are calling. For example, if you expect
+    # a binary download, and the server sends you an error message and you don't really want to bother figuring out
+    # the encoding it has - but you need to append this response to an error log or similar.
+    #
+    # @see Patron::Response#decoded_body
+    # @return [String, nil]
+    def inspectable_body
+      return unless @body
+      @inspectable_body ||= decode_body(strict=false)
     end
-
-    def validate_charset(charset)
-      charset && Encoding.find(charset) && true
-    rescue ArgumentError
+    
+    # Tells whether the response body can be decoded losslessly into the curren internal encoding
+    #
+    # @return [Boolean] true if the body is decodable, false if otherwise
+    def body_decodable?
+      return true if @body.nil?
+      return true if decoded_body
+    rescue HeaderCharsetInvalid, NonRepresentableBody
       false
     end
-
-    def convert_to_default_encoding!(str)
-      if str.respond_to?(:encode) && Encoding.default_internal
-        str.force_encoding(charset).encode!(Encoding.default_internal)
-      end
-    end
+    
+    private
 
     # Called by the C code to parse and set the headers
     def parse_headers(header_data)
@@ -124,6 +147,5 @@ module Patron
         end
       end
     end
-
   end
 end

--- a/lib/patron/response_decoding.rb
+++ b/lib/patron/response_decoding.rb
@@ -1,0 +1,123 @@
+## -------------------------------------------------------------------
+##
+## Patron HTTP Client: Response class
+## Copyright (c) 2008 The Hive http://www.thehive.com/
+##
+## Permission is hereby granted, free of charge, to any person obtaining a copy
+## of this software and associated documentation files (the "Software"), to deal
+## in the Software without restriction, including without limitation the rights
+## to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+## copies of the Software, and to permit persons to whom the Software is
+## furnished to do so, subject to the following conditions:
+##
+## The above copyright notice and this permission notice shall be included in
+## all copies or substantial portions of the Software.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+## AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+## LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+## OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+## THE SOFTWARE.
+##
+## -------------------------------------------------------------------
+
+
+module Patron
+  # Contains methods used for decoding the HTTP response body. These are only ever used internally
+  # by the Response class.
+  module ResponseDecoding
+    
+    private
+
+    CHARSET_CONTENT_TYPE_RE = /(?:charset|encoding)="?([a-z0-9-]+)"?/i.freeze
+    
+    MISREPORTED_ENCODING_ERROR = <<-EOF
+The server stated that the response has the charset matching %{declared}, but the actual
+response body failed to decode as such (not flagged as `valid_encoding?')
+Maybe the response body has a different encoding than suggested by the
+server, or a binary response has been tagged by the server as text by mistake.
+If you are performing requests against servers that are known to report wrong or invalid charsets, use
+`Response#body' instead and handle the character set coercion externally. For instance, you may elect to parse
+the resulting HTML/XML for charset declarations.
+EOF
+  
+    INVALID_CHARSET_NAME_ERROR = <<-EOF
+The server specified an invalid charset in the Content-Type header (%{content_type}), \
+or Ruby does not support this charset. If you are performing requests against servers \
+that are known to report wrong or invalid charsets, use 'Response#body` instead \
+and handle the character set coercion at call site.
+EOF
+    
+    INTERNAL_CHARSET_MISMATCH_ERROR = <<-EOF
+The response body is %{source_encoding}, but the current \
+`Encoding.default_internal' (or the encoding for a new empty string if you never \
+set `Encoding.default_internal') - %{target_encoding} - cannot be used to represent the response body in \
+a lossless way. Your options are:
+a) using `Response#body' instead
+b) switching your Ruby process to an encoding that supports the needed repertoire
+c) using `Response#inspectable_body' to convert the body in a lossy way
+EOF
+
+    def decode_body(strict)
+      # Try to detect the body encoding from headers
+      body_encoding = encoding_from_headers_or_binary
+  
+      # See if the body actually _is_ in this encoding. 
+      encoding_matched = @body.force_encoding(body_encoding).valid_encoding?
+      if !encoding_matched
+        raise HeaderCharsetInvalid,  MISREPORTED_ENCODING_ERROR % {declared: body_encoding}
+      end
+  
+      if strict
+        convert_encoding_and_raise(@body)
+      else
+        @body.encode(internal_encoding, :undefined => :replace, :replace => '?')
+      end
+    end
+
+    def convert_encoding_and_raise(str)
+      internal = internal_encoding
+      str.encode(internal)
+    rescue Encoding::UndefinedConversionError => e
+      enc = str.encoding == Encoding::BINARY ? 'binary' : str.encoding.to_s
+      raise NonRepresentableBody,
+        INTERNAL_CHARSET_MISMATCH_ERROR % {source_encoding: enc, target_encoding: internal}
+    end
+    
+    def charset_from_content_type
+      return $1 if @headers["Content-Type"].to_s =~ CHARSET_CONTENT_TYPE_RE
+    end
+    
+    def encoding_from_headers_or_binary
+      return Encoding::BINARY unless charset_name = charset_from_content_type
+      Encoding.find(charset_name)
+    rescue ArgumentError => e # invalid charset name
+      raise HeaderCharsetInvalid,
+            INVALID_CHARSET_NAME_ERROR % {content_type: @headers['Content-Type'].inspect}
+    end
+    
+    def internal_encoding
+      # Use a trick here - instead of using `default_internal` we will create
+      # an empty string, and then get it's encoding instead. For example, this holds
+      # true on 2.1+ on OSX:
+      #
+      #     Encoding.default_internal #=> nil
+      #     ''.encoding #=> #<Encoding:UTF-8>
+      Encoding.default_internal || ''.encoding
+    end
+    
+    def decode_header_data(str)
+      # Header data is tricky. Strictly speaking, it _must_ be ISO-encoded. However, Content-Disposition
+      # sometimes gets sent as raw UTF8 - and most browsers (except for localized IE versions on Windows)
+      # treat it as such. So a fallback chain of 8859-1->UTF8->binary seems the most sane.
+      tries = [Encoding::ISO8859_1, Encoding::UTF_8, Encoding::BINARY]
+      tries.each do |possible_enc|
+        return str if str.force_encoding(possible_enc).valid_encoding?
+      end
+    end
+  end
+  
+  private_constant :ResponseDecoding if respond_to?(:private_constant)
+end

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -27,6 +27,7 @@
 require 'uri'
 require 'patron/error'
 require 'patron/request'
+require 'patron/response_decoding'
 require 'patron/response'
 require 'patron/session_ext'
 require 'patron/util'
@@ -340,9 +341,9 @@ module Patron
     # the Request object, and not it's public methods.
     #
     # @param action[String] the HTTP verb
-    # @paran url[#to_s] the addition to the base url component, or a complete URL
-    # @paran headers[Hash] a hash of headers, "Accept" will be automatically set to an empty string if not provided
-    # @paran options[Hash] any overriding options (will shadow the options from the Session object)
+    # @param url[#to_s] the addition to the base url component, or a complete URL
+    # @param headers[Hash] a hash of headers, "Accept" will be automatically set to an empty string if not provided
+    # @param options[Hash] any overriding options (will shadow the options from the Session object)
     # @return [Patron::Request] the request that will be passed to ++handle_request++
     def build_request(action, url, headers, options = {})
       # If the Expect header isn't set uploads are really slow

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -32,6 +32,12 @@ require 'base64'
 require 'fileutils'
 
 describe Patron::Response do
+  around(:each) do |example|
+    previous_internal = Encoding.default_internal
+    example.run
+    Encoding.default_internal = previous_internal
+  end
+  
   before(:each) do
     @session = Patron::Session.new
     @session.base_url = "http://localhost:9001"
@@ -47,47 +53,67 @@ describe Patron::Response do
     response = @session.get("/repetitiveheader")
     expect(response.headers['Set-Cookie']).to be == ["a=1","b=2"]
   end
+  
+  describe '#decoded_body and #inspectable_body' do
+    it "should raise with explicitly binary response bodies but allow an inspectable body" do
+      Encoding.default_internal = Encoding::UTF_8
+      response = @session.get("/picture")
+      expect(response.headers['Content-Type']).to be == 'image/png'
+      expect(response.body.encoding).to be == Encoding::BINARY
+      expect(response).not_to be_body_decodable
+      expect {
+        response.decoded_body
+      }.to raise_error(Patron::NonRepresentableBody)
+      
+      inspectable = response.inspectable_body
+      expect(inspectable.encoding).to eq(Encoding::UTF_8)
+      expect(inspectable).to be_valid_encoding
+    end
+    
+    it "should encode body in the internal charset" do
+      allow(Encoding).to receive(:default_internal).and_return("UTF-8")
 
-  it "should works with non-text files" do
-    response = @session.get("/picture")
-    expect(response.headers['Content-Type']).to be == 'image/png'
-    expect(response.body.encoding).to be == Encoding::ASCII_8BIT
+      greek_encoding = Encoding.find("ISO-8859-7")
+      utf_encoding = Encoding.find("UTF-8")
+
+      headers = "HTTP/1.1 200 OK \r\nContent-Type: text/css;charset=ISO-8859-7\r\n"
+      body = "Ππ".encode(greek_encoding) # Greek alphabet
+
+      response = Patron::Response.new("url", "status", 0, headers, body, nil)
+
+      expect(response).to be_body_decodable
+      expect(response.decoded_body.encoding).to eql(utf_encoding)
+    end
+    
+    it "should fallback to default charset when header or body charset is not valid" do
+      allow(Encoding).to receive(:default_internal).and_return("UTF-8")
+
+      encoding = Encoding.find("UTF-8")
+      headers = "HTTP/1.1 200 OK \r\nContent-Type: text/css; charset=invalid\r\n"
+      body = "who knows which encoding this CSS is in?"
+
+      response = Patron::Response.new("url", "status", 0, headers, body, "UTF-8")
+      expect(response.charset).to eq('invalid')
+      
+      expect(response).not_to be_body_decodable
+      expect {
+        response.decoded_body
+      }.to raise_error(Patron::HeaderCharsetInvalid)
+    end
   end
 
-  it "should not allow a default charset to be nil" do
-    allow(Encoding).to receive(:default_internal).and_return("UTF-8")
-    expect {
-      Patron::Response.new("url", "status", 0, "", "", nil)
-    }.to_not raise_error
-  end
-
-  it "should be able to serialize and deserialize itself" do
-    expect(Marshal.load(Marshal.dump(@request))).to eql(@request)
-  end
-
-  it "should encode body in the internal charset" do
-    allow(Encoding).to receive(:default_internal).and_return("UTF-8")
-
-    greek_encoding = Encoding.find("ISO-8859-7")
-    utf_encoding = Encoding.find("UTF-8")
-
-    headers = "HTTP/1.1 200 OK \r\nContent-Type: text/css\r\n"
-    body = "charset=ISO-8859-7 Ππ".encode(greek_encoding) # Greek alphabet
-
-    response = Patron::Response.new("url", "status", 0, headers, body, nil)
-
-    expect(response.body.encoding).to eql(utf_encoding)
-  end
-
-  it "should fallback to default charset when header or body charset is not valid" do
-    allow(Encoding).to receive(:default_internal).and_return("UTF-8")
-
+  it "decodes a header that contains UTF-8 even though internal encoding is ASCII" do
+    Encoding.default_internal = Encoding::ASCII
     encoding = Encoding.find("UTF-8")
-    headers = "HTTP/1.1 200 OK \r\nContent-Type: text/css\r\n"
-    body = "charset=invalid"
+    headers = "HTTP/1.1 200 OK \r\nContent-Disposition: attachment,filename=\"файлец.txt\"\r\n"
+    body = "this is a file with a Russian filename set in content-disposition"
 
     response = Patron::Response.new("url", "status", 0, headers, body, "UTF-8")
-
-    expect(response.body.encoding).to eql(encoding)
+    dispo = response.headers['Content-Disposition']
+    expect(dispo.encoding).to eq(Encoding::UTF_8)
+  end
+  
+  it "should be able to serialize and deserialize itself" do
+    expect(Marshal.load(Marshal.dump(@request))).to eql(@request)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ if ENV["COVERAGE"]
 end
 
 require 'rspec'
+
 # Kill warnings that not raising a specific exception still allows the method
 # to fail with another exception
 RSpec::Expectations.configuration.warn_about_potential_false_positives = false


### PR DESCRIPTION
@toland can you take a look and tell me if this matches your ideas about the charset handling rework? The only noticeable difference is that implicit coercion for `Response#body` is removed altogether, and body is assumed to be binary.