### PR TITLE
Simplify extconf

### DIFF
--- a/ext/patron/extconf.rb
+++ b/ext/patron/extconf.rb
@@ -35,7 +35,7 @@ elsif !have_library('curl') or !have_header('curl/curl.h')
   fail <<-EOM
   Can't find libcurl or curl/curl.h
 
-  Try passing --with-curl-dir or --with-curl-lib and --with-curl-include
+  Try passing --with-curl-config, --with-curl-dir, or --with-curl-lib and --with-curl-include
   options to extconf.
   EOM
 end

--- a/ext/patron/extconf.rb
+++ b/ext/patron/extconf.rb
@@ -27,13 +27,10 @@ require 'mkmf'
 require 'rbconfig'
 
 dir_config('curl')
-
-if curl_config_path = with_config('curl-config')
-  $CFLAGS << " #{`#{curl_config_path} --cflags`.strip}"
-  $LIBS << " #{`#{curl_config_path} --libs`.strip}"
-elsif find_executable('curl-config')
-  $CFLAGS << " #{`curl-config --cflags`.strip}"
-  $LIBS << " #{`curl-config --libs`.strip}"
+curl_config_path = with_config('curl-config') || find_executable('curl-config')
+if curl_config_path
+  $CFLAGS << " " << `#{curl_config_path} --cflags`.strip
+  $LIBS << " " << `#{curl_config_path} --libs`.strip
 elsif !have_library('curl') or !have_header('curl/curl.h')
   fail <<-EOM
   Can't find libcurl or curl/curl.h


### PR DESCRIPTION
to remove double (or even triple) string templating