### PR TITLE
Set the default User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.6.4
 
+* Set the default User-Agent string, since some sites require it (like the Github API).
 * Add Response#ok? and Response#error? for cleaner branching on the returned Response objects
 * Explain a segfault with SSL in forked processes on OSX, document the way to avoid the issue
 * Fix segfault when attempting multiple post requests with multipart (#119)

--- a/lib/patron.rb
+++ b/lib/patron.rb
@@ -39,7 +39,7 @@ module Patron
     VERSION
   end
   
-  # Returns the default Uset-Agent string
+  # Returns the default User-Agent string
   # @return [String]
   def self.user_agent_string
     @ua ||= "Patron/Ruby-%s-%s" % [version, libcurl_version]

--- a/lib/patron.rb
+++ b/lib/patron.rb
@@ -38,4 +38,10 @@ module Patron
   def self.version
     VERSION
   end
+  
+  # Returns the default Uset-Agent string
+  # @return [String]
+  def self.user_agent_string
+    @ua ||= "Patron/Ruby-%s-%s" % [version, libcurl_version]
+  end
 end

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -107,7 +107,7 @@ module Patron
     
     private :handle_request, :add_cookie_file, :set_debug_file
 
-    # Create a new Session object.
+    # Create a new Session object for performing requests.
     #
     # @param args[Hash] options for the Session (same names as the writable attributes of the Session)
     # @yield self
@@ -124,6 +124,7 @@ module Patron
       end
 
       @headers ||= {}
+      @headers['User-Agent'] ||= Patron.user_agent_string
       @timeout ||= 5
       @connect_timeout ||= 1
       @max_redirects ||= 5

--- a/spec/patron_spec.rb
+++ b/spec/patron_spec.rb
@@ -27,6 +27,12 @@ require File.expand_path("./spec") + '/spec_helper.rb'
 
 describe Patron do
 
+  it 'should return the user agent string' do
+    ua_str = Patron.user_agent_string
+    expect(ua_str).to include('curl')
+    expect(ua_str).to include('Patron')
+  end
+  
   it "should return the version number of the Patron library" do
     version = Patron.version
     expect(version).to match(%r|^\d+.\d+.\d+$|)

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -107,6 +107,19 @@ describe Patron::Session do
     FileUtils.rm tmpfile
   end
 
+  it "should not send the user-agent if it has been deleted from headers" do
+    @session.headers.delete 'User-Agent'
+    response = @session.get("/test")
+    body = YAML::load(response.body)
+    expect(body.header["user-agent"]).to be_nil
+  end
+  
+  it "should set the default User-agent" do
+    response = @session.get("/test")
+    body = YAML::load(response.body)
+    expect(body.header["user-agent"]).to be == [Patron.user_agent_string]
+  end
+
   it "should include custom headers in a request" do
     response = @session.get("/test", {"User-Agent" => "PatronTest"})
     body = YAML::load(response.body)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,8 @@ $:.unshift(File.dirname(__FILE__) + '/../lib')
 $:.unshift(File.dirname(__FILE__) + '/../ext')
 require 'patron'
 
+$stderr.puts "Build against #{Patron.libcurl_version}"
+
 Dir['./spec/support/**/*.rb'].each { |fn| require fn }
 
 PatronTestServer.start(nil, false, 9001) if RUBY_VERSION >= '1.9'


### PR DESCRIPTION
I was recently bitten by the fact that Github wants User-Agent to be set, and this was not in my code. I think it is a good idea to set a descriptive header by default, since you can remove it if you want to

    sess.headers.delete 'User-Agent'