### PR TITLE
Forbid non-HTTP/HTTPS URLs for requests and do not allow redirect to such URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Prevent libCURL from doing requests to non-HTTP/HTTPS URLs, and from following redirects to such URLs
+
 ### 0.6.4
 
 * Set the default User-Agent string, since some sites require it (like the Github API).

--- a/README.md
+++ b/README.md
@@ -92,10 +92,14 @@ For sharing a resource of sessions between threads we recommend using the excell
 
 ## Requirements
 
-You need a recent version of libcurl in order to install this gem. On MacOS X
-the provided libcurl is sufficient. You will have to install the libcurl
+Patron uses encoding features of Ruby, so you need at least Ruby 1.9. Also, a
+recent version of libCURL is required. We recommend at least 7.19.4 because
+it [supports limiting the protocols](https://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html),
+and that is very important for security - especially if you follow redirects. 
+
+On OSX the provided libcurl is sufficient. You will have to install the libcurl
 development packages on Debian or Ubuntu. Other Linux systems are probably
-similar. Windows users are on your own. Good luck with that.
+similar. For Windows we do not have an established build instruction at the moment, unfortunately.
 
 ## Installation
 

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -471,11 +471,9 @@ static void set_options_from_request(VALUE self, VALUE request) {
   }
   curl_easy_setopt(curl, CURLOPT_URL, StringValuePtr(url));
   
-#ifdef CURLOPT_PROTOCOLS
+#ifdef CURLPROTO_HTTP
+  // Security: do not allow Curl to go looking on gopher/SMTP etc.
   curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-#endif
-
-#ifdef CURLOPT_REDIR_PROTOCOLS
   curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 #endif
     

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -473,6 +473,8 @@ static void set_options_from_request(VALUE self, VALUE request) {
   
 #ifdef CURLPROTO_HTTP
   // Security: do not allow Curl to go looking on gopher/SMTP etc.
+  // Must prevent situations like this:
+  // https://hackerone.com/reports/115748
   curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
   curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 #endif

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -470,7 +470,15 @@ static void set_options_from_request(VALUE self, VALUE request) {
     rb_raise(rb_eArgError, "Must provide a URL");
   }
   curl_easy_setopt(curl, CURLOPT_URL, StringValuePtr(url));
+  
+#ifdef CURLOPT_PROTOCOLS
+  curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
 
+#ifdef CURLOPT_REDIR_PROTOCOLS
+  curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
+    
   timeout = rb_funcall(request, rb_intern("timeout"), 0);
   if (RTEST(timeout)) {
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, FIX2INT(timeout));

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -48,7 +48,14 @@ describe Patron::Session do
     end
   end
   
-  it 'does not follow a redirect to a non-HTTP/HTTPS URL'
+  it 'does not follow a redirect to a non-HTTP/HTTPS URL' do
+    # The "/evil-redirect" servlet tries to do a redirect to SMTP,
+    # which can lead to exploits. By default, libCURL will just follow
+    # that redirect.
+    expect {
+      @session.get('/evil-redirect')
+    }.to raise_error(Patron::UnsupportedProtocol)
+  end
   
   it "should work when forcing ipv4" do
     @session.force_ipv4 = true

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -36,6 +36,20 @@ describe Patron::Session do
     @session.base_url = "http://localhost:9001"
   end
 
+  context 'when trying a non-HTTP(s) URL' do
+    forbidden_protos = %w( smb tftp imap smtp telnet dict ftp sftp scp file gopher )
+    forbidden_protos.each do |forbidden_proto|
+      it "should deny a #{forbidden_proto.upcase} request" do
+        @session.base_url = nil
+        expect {
+          @session.get('%s://localhost' % forbidden_proto)
+        }.to raise_error(Patron::UnsupportedProtocol)
+      end
+    end
+  end
+  
+  it 'does not follow a redirect to a non-HTTP/HTTPS URL'
+  
   it "should work when forcing ipv4" do
     @session.force_ipv4 = true
     expect { @session.get("/test") }.to_not raise_error

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -108,6 +108,13 @@ class RedirectServlet < HTTPServlet::AbstractServlet
   end
 end
 
+class EvilRedirectServlet < HTTPServlet::AbstractServlet
+  def do_GET(req,res)
+    res['Location'] = "smtp://mailbox:secret@localhost"
+    res.status = 301
+  end
+end
+
 class TestPostBodyServlet < HTTPServlet::AbstractServlet
   include RespondWith
   def do_POST(req, res)
@@ -188,6 +195,7 @@ class PatronTestServer
     @server.mount("/testpatch", TestPatchBodyServlet)
     @server.mount("/timeout", TimeoutServlet)
     @server.mount("/redirect", RedirectServlet)
+    @server.mount("/evil-redirect", EvilRedirectServlet)
     @server.mount("/picture", PictureServlet)
     @server.mount("/setcookie", SetCookieServlet)
     @server.mount("/repetitiveheader", RepetitiveHeaderServlet)


### PR DESCRIPTION
I think this is going to be a good security-minded check (see the imgur SSRF drama, which involved leading curl to a non-authorised URL by doing a remote-fetch-by-proxy).