### PR TITLE
Allow the `data' argument to put() etc. to be a File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Allow Ruby File objects to be passed as `data` to `Session#put`, `Sesion#post` etc.
+
 ### 0.6.5
 
 * Prevent libCURL from doing requests to non-HTTP/HTTPS URLs, and from following redirects to such URLs

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -226,7 +226,9 @@ module Patron
     #
     # @todo inconsistency with "post" - Hash not accepted
     # @param url[String] the URL to fetch
-    # @param data[#to_s] an object that can be converted to a String to create the request body
+    # @param data[#to_s, #to_path] an object that can be converted to a String
+    #   to create the request body, or that responds to #to_path to upload the
+    #   entire request body from that file
     # @param headers[Hash] the hash of header keys to values
     # @return [Patron::Response]
     def put(url, data, headers = {})
@@ -238,7 +240,9 @@ module Patron
     #
     # @todo inconsistency with "post" - Hash not accepted
     # @param url[String] the URL to fetch
-    # @param data[#to_s] an object that can be converted to a String to create the request body
+    # @param data[#to_s, #to_path] an object that can be converted to a String
+    #   to create the request body, or that responds to #to_path to upload the
+    #   entire request body from that file
     # @param headers[Hash] the hash of header keys to values
     # @return [Patron::Response]
     def patch(url, data, headers = {})
@@ -259,7 +263,10 @@ module Patron
     # Uploads the passed `data` to the specified `url` using an HTTP POST.
     #
     # @param url[String] the URL to fetch
-    # @param data[Hash, #to_s] a Hash of form fields/values, or an object that can be converted to a String to create the request body
+    # @param data[Hash, #to_s, #to_path] a Hash of form fields/values,
+    #   or an object that can be converted to a String
+    #   to create the request body, or an object that responds to #to_path to upload the
+    #   entire request body from that file
     # @param headers[Hash] the hash of header keys to values
     # @return [Patron::Response]
     def post(url, data, headers = {})
@@ -292,7 +299,6 @@ module Patron
     def post_multipart(url, data, filename, headers = {})
       request(:post, url, headers, {:data => data, :file => filename, :multipart => true})
     end
-
 
     # @!group WebDAV methods
     # Sends a WebDAV COPY request to the specified +url+.

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -248,6 +248,17 @@ describe Patron::Session do
     expect(body.header['content-length']).to be == [data.size.to_s]
   end
 
+  it "should upload a Tempfile with :put" do
+    data = Tempfile.new 'data-buffer'
+    data << Random.new.bytes(1024 * 64)
+    data.flush; data.rewind
+    
+    response = @session.put("/test", data, {'Expect' => ''})
+    body = YAML::load(response.body)
+    expect(body.request_method).to be == "PUT"
+    expect(body.header['content-length']).to be == [data.size.to_s]
+  end
+  
   it "should upload data with :patch" do
     data = "upload data"
     response = @session.patch("/testpatch", data)


### PR DESCRIPTION
Allow a simpler way to set a Ruby File object as data argument for performing uploads. This is majorly useful for endpoints that accept verbatim uploads without multipart wrapping. Next step is getting rid of the filename multi-args, but I think it is better to do in 2.0 once we can cut 1.0 because it will have us revamp APIs ;-)