### PR TITLE
New libCURL options for HTTP Version and SSL Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### MASTER
+
+* Added ssl_version options "TLSv1_1", "TLSv1_2", "TLSv1_3" for use per the libCURL documentation
+    * requires the appropriate versions of libCURL and OpenSSL installed to support these new options 
+    * reference: https://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html
+* Added a new http_version option with "HTTPv1_1", and "HTTPv2_0" options to set the HTTP version of HTTP/1.1 or HTTP/2.0
+    * requires the appropriate versions of libCURL and OpenSSL installed to support these new options 
+    * reference: https://curl.haxx.se/libcurl/c/CURLOPT_HTTP_VERSION.html
+
 ### 0.8.0
 
 * Add `Response#inspectable_body`, `Response#decoded_body`. `decoded_body` will atempt to decode

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -594,13 +594,26 @@ static void set_options_from_request(VALUE self, VALUE request) {
       curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
     } else if(strcmp(version, "HTTPv1_1") == 0) {
           curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-    } else if(strcmp(version, "HTTPv2_0") == 0) {
-      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0); //libcurl v7.33.0+
-    } else if(strcmp(version, "HTTPv2_TLS") == 0) {
-      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS); //libcurl v7.47.0+
-    } else if(strcmp(version, "HTTPv2_PRIOR") == 0) {
-      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE); //libcurl v7.49.0+
-    } else {
+    }
+    #if LIBCURL_VERSION_NUM >= 0x072100
+        /* this is libCURLv7.33.0 or later */
+        else if(strcmp(version, "HTTPv2_0") == 0) {
+          curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0); //libcurl v7.33.0+
+        }
+    #endif
+    #if LIBCURL_VERSION_NUM >= 0x072F00
+        /* this is libCURLv7.47.0 or later */
+        else if(strcmp(version, "HTTPv2_TLS") == 0) {
+          curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS); //libcurl v7.47.0+
+        }
+    #endif
+    #if LIBCURL_VERSION_NUM >= 0x073100
+        /* this is libCURLv7.49.0 or later */
+        else if(strcmp(version, "HTTPv2_PRIOR") == 0) {
+          curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE); //libcurl v7.49.0+
+        }
+    #endif
+    else {
       rb_raise(eUnsupportedHTTPVersion, "Unsupported HTTP version: %s", version);
     }
   }

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -555,21 +555,31 @@ static void set_options_from_request(VALUE self, VALUE request) {
   if(RTEST(ssl_version)) {
     VALUE ssl_version_str = rb_funcall(ssl_version, rb_intern("to_s"), 0);
     char* version = StringValuePtr(ssl_version_str);
+
     if(strcmp(version, "SSLv2") == 0) {
       curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_SSLv2);
     } else if(strcmp(version, "SSLv3") == 0) {
       curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_SSLv3);
     } else if(strcmp(version, "TLSv1") == 0) {
           curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
-    } else if(strcmp(version, "TLSv1_0") == 0) {
-      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_0); //libcurl v7.34.0+
-    } else if(strcmp(version, "TLSv1_1") == 0) {
-      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1); //libcurl v7.34.0+
-    } else if(strcmp(version, "TLSv1_2") == 0) {
-      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); //libcurl v7.34.0+
-    } else if(strcmp(version, "TLSv1_3") == 0) {
-      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_3); //libcurl v7.52.0+
-    } else {
+    }
+    #if LIBCURL_VERSION_NUM >= 0x072200
+        /* this is libCURLv7.34.0 or later */
+        else if(strcmp(version, "TLSv1_0") == 0) {
+          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_0); //libcurl v7.34.0+
+        } else if(strcmp(version, "TLSv1_1") == 0) {
+          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1); //libcurl v7.34.0+
+        } else if(strcmp(version, "TLSv1_2") == 0) {
+          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); //libcurl v7.34.0+
+        }
+    #endif
+    #if LIBCURL_VERSION_NUM >= 0x073400
+        /* this is libCURLv7.52.0 or later */
+        else if(strcmp(version, "TLSv1_3") == 0) {
+          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_3); //libcurl v7.52.0+
+        }
+    #endif
+    else {
       rb_raise(eUnsupportedSSLVersion, "Unsupported SSL version: %s", version);
     }
   }

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -40,6 +40,7 @@ static VALUE cRequest = Qnil;
 static VALUE ePatronError = Qnil;
 static VALUE eUnsupportedProtocol = Qnil;
 static VALUE eUnsupportedSSLVersion = Qnil;
+static VALUE eUnsupportedHTTPVersion = Qnil;
 static VALUE eURLFormatError = Qnil;
 static VALUE eHostResolutionError = Qnil;
 static VALUE eConnectionFailed = Qnil;
@@ -383,6 +384,7 @@ static void set_options_from_request(VALUE self, VALUE request) {
   VALUE insecure              = Qnil;
   VALUE cacert                = Qnil;
   VALUE ssl_version           = Qnil;
+  VALUE http_version          = Qnil;
   VALUE buffer_size           = Qnil;
   VALUE action_name           = rb_funcall(request, rb_intern("action"), 0);
   VALUE a_c_encoding          = rb_funcall(request, rb_intern("automatic_content_encoding"), 0);
@@ -558,9 +560,38 @@ static void set_options_from_request(VALUE self, VALUE request) {
     } else if(strcmp(version, "SSLv3") == 0) {
       curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_SSLv3);
     } else if(strcmp(version, "TLSv1") == 0) {
-      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+    } else if(strcmp(version, "TLSv1_0") == 0) {
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_0); //libcurl v7.34.0+
+    } else if(strcmp(version, "TLSv1_1") == 0) {
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1); //libcurl v7.34.0+
+    } else if(strcmp(version, "TLSv1_2") == 0) {
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); //libcurl v7.34.0+
+    } else if(strcmp(version, "TLSv1_3") == 0) {
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_3); //libcurl v7.52.0+
     } else {
       rb_raise(eUnsupportedSSLVersion, "Unsupported SSL version: %s", version);
+    }
+  }
+
+  http_version = rb_funcall(request, rb_intern("http_version"), 0);
+  if(RTEST(http_version)) {
+    VALUE http_version_str = rb_funcall(http_version, rb_intern("to_s"), 0);
+    char* version = StringValuePtr(http_version_str);
+    if(strcmp(version, "None") == 0) {
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_NONE);
+    } else if(strcmp(version, "HTTPv1_0") == 0) {
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+    } else if(strcmp(version, "HTTPv1_1") == 0) {
+          curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+    } else if(strcmp(version, "HTTPv2_0") == 0) {
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0); //libcurl v7.33.0+
+    } else if(strcmp(version, "HTTPv2_TLS") == 0) {
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS); //libcurl v7.47.0+
+    } else if(strcmp(version, "HTTPv2_PRIOR") == 0) {
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE); //libcurl v7.49.0+
+    } else {
+      rb_raise(eUnsupportedHTTPVersion, "Unsupported HTTP version: %s", version);
     }
   }
 
@@ -826,6 +857,7 @@ void Init_session_ext() {
 
   eUnsupportedProtocol = rb_const_get(mPatron, rb_intern("UnsupportedProtocol"));
   eUnsupportedSSLVersion = rb_const_get(mPatron, rb_intern("UnsupportedSSLVersion"));
+  eUnsupportedHTTPVersion = rb_const_get(mPatron, rb_intern("UnsupportedHTTPVersion"));
   eURLFormatError = rb_const_get(mPatron, rb_intern("URLFormatError"));
   eHostResolutionError = rb_const_get(mPatron, rb_intern("HostResolutionError"));
   eConnectionFailed = rb_const_get(mPatron, rb_intern("ConnectionFailed"));

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -564,20 +564,20 @@ static void set_options_from_request(VALUE self, VALUE request) {
           curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
     }
     #if LIBCURL_VERSION_NUM >= 0x072200
-        /* this is libCURLv7.34.0 or later */
-        else if(strcmp(version, "TLSv1_0") == 0) {
-          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_0); //libcurl v7.34.0+
-        } else if(strcmp(version, "TLSv1_1") == 0) {
-          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1); //libcurl v7.34.0+
-        } else if(strcmp(version, "TLSv1_2") == 0) {
-          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); //libcurl v7.34.0+
-        }
+    /* this is libCURLv7.34.0 or later */
+    else if(strcmp(version, "TLSv1_0") == 0) {
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_0); //libcurl v7.34.0+
+    } else if(strcmp(version, "TLSv1_1") == 0) {
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1); //libcurl v7.34.0+
+    } else if(strcmp(version, "TLSv1_2") == 0) {
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); //libcurl v7.34.0+
+    }
     #endif
     #if LIBCURL_VERSION_NUM >= 0x073400
-        /* this is libCURLv7.52.0 or later */
-        else if(strcmp(version, "TLSv1_3") == 0) {
-          curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_3); //libcurl v7.52.0+
-        }
+    /* this is libCURLv7.52.0 or later */
+    else if(strcmp(version, "TLSv1_3") == 0) {
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_3); //libcurl v7.52.0+
+    }
     #endif
     else {
       rb_raise(eUnsupportedSSLVersion, "Unsupported SSL version: %s", version);
@@ -596,22 +596,22 @@ static void set_options_from_request(VALUE self, VALUE request) {
           curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
     }
     #if LIBCURL_VERSION_NUM >= 0x072100
-        /* this is libCURLv7.33.0 or later */
-        else if(strcmp(version, "HTTPv2_0") == 0) {
-          curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0); //libcurl v7.33.0+
-        }
+    /* this is libCURLv7.33.0 or later */
+    else if(strcmp(version, "HTTPv2_0") == 0) {
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0); //libcurl v7.33.0+
+    }
     #endif
     #if LIBCURL_VERSION_NUM >= 0x072F00
-        /* this is libCURLv7.47.0 or later */
-        else if(strcmp(version, "HTTPv2_TLS") == 0) {
-          curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS); //libcurl v7.47.0+
-        }
+    /* this is libCURLv7.47.0 or later */
+    else if(strcmp(version, "HTTPv2_TLS") == 0) {
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS); //libcurl v7.47.0+
+    }
     #endif
     #if LIBCURL_VERSION_NUM >= 0x073100
-        /* this is libCURLv7.49.0 or later */
-        else if(strcmp(version, "HTTPv2_PRIOR") == 0) {
-          curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE); //libcurl v7.49.0+
-        }
+    /* this is libCURLv7.49.0 or later */
+    else if(strcmp(version, "HTTPv2_PRIOR") == 0) {CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE); //libcurl v7.49.0+
+    }
     #endif
     else {
       rb_raise(eUnsupportedHTTPVersion, "Unsupported HTTP version: %s", version);

--- a/lib/patron/error.rb
+++ b/lib/patron/error.rb
@@ -36,6 +36,9 @@ module Patron
   # Gets raised when a request is attempted with an unsupported SSL version.
   class UnsupportedSSLVersion  < Error; end
 
+  # Gets raised when a request is attempted with an unsupported HTTP version.
+  class UnsupportedHTTPVersion  < Error; end
+
   # Gets raised when the URL was not properly formatted.
   class URLFormatError         < Error; end
 

--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -50,12 +50,12 @@ module Patron
       :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
       :ignore_content_length, :multipart, :action, :timeout, :connect_timeout,
       :max_redirects, :headers, :auth_type, :upload_data, :buffer_size, :cacert,
-      :ssl_version, :automatic_content_encoding, :force_ipv4
+      :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4
     ]
 
     WRITER_VARS = [
       :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
-      :ignore_content_length, :multipart, :cacert, :ssl_version, :automatic_content_encoding, :force_ipv4
+      :ignore_content_length, :multipart, :cacert, :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4
     ]
 
     attr_reader *READER_VARS

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -82,6 +82,10 @@ module Patron
     # The supported values are nil, "SSLv2", "SSLv3", and "TLSv1".
     attr_accessor :ssl_version
 
+    # @return [String] the HTTP version for the requests, or "None" if libcurl is to choose permitted versions
+    # The supported values are "None", "HTTPv1_0", "HTTPv1_1", "HTTPv2_0", "HTTPv2_TLS", and "HTTPv2_PRIOR".
+    attr_accessor :http_version
+
     # @return [String] path to the CA file used for certificate verification, or `nil` if CURL default is used
     attr_accessor :cacert
 
@@ -371,6 +375,7 @@ module Patron
         req.auth_type              = options.fetch :auth_type,             self.auth_type
         req.insecure               = options.fetch :insecure,              self.insecure
         req.ssl_version            = options.fetch :ssl_version,           self.ssl_version
+        req.http_version           = options.fetch :http_version,          self.http_version
         req.cacert                 = options.fetch :cacert,                self.cacert
         req.ignore_content_length  = options.fetch :ignore_content_length, self.ignore_content_length
         req.buffer_size            = options.fetch :buffer_size,           self.buffer_size

--- a/spec/session_ssl_spec.rb
+++ b/spec/session_ssl_spec.rb
@@ -284,7 +284,7 @@ describe Patron::Session do
   end
 
   it "should work with different SSL versions" do
-    ['SSLv3', 'TLSv1'].each do |version|
+    ['SSLv3','TLSv1_2'].each do |version|
       @session.ssl_version = version
       response = @session.get("/test")
       expect(response.status).to be == 200
@@ -299,7 +299,24 @@ describe Patron::Session do
       }.to raise_error(Patron::UnsupportedSSLVersion)
     end
   end
-  
+
+  it "should work with different HTTP versions" do
+    ['HTTPv1_1','HTTPv2_0'].each do |version|
+      @session.http_version = version
+      response = @session.get("/test")
+      expect(response.status).to be == 200
+    end
+  end
+
+  it "should raise when an unsupported or unknown HTTP version is requested" do
+    ['something', 1].each do |version|
+      @session.http_version = version
+      expect {
+        @session.get("/test")
+      }.to raise_error(Patron::UnsupportedHTTPVersion)
+    end
+  end
+
   # ------------------------------------------------------------------------
   describe 'when debug is enabled' do
     it 'it should not clobber stderr' do

--- a/spec/session_ssl_spec.rb
+++ b/spec/session_ssl_spec.rb
@@ -284,7 +284,7 @@ describe Patron::Session do
   end
 
   it "should work with different SSL versions" do
-    ['SSLv3','TLSv1_2'].each do |version|
+    ['SSLv3','TLSv1'].each do |version|
       @session.ssl_version = version
       response = @session.get("/test")
       expect(response.status).to be == 200
@@ -301,7 +301,7 @@ describe Patron::Session do
   end
 
   it "should work with different HTTP versions" do
-    ['HTTPv1_1','HTTPv2_0'].each do |version|
+    ['HTTPv1_0','HTTPv1_1'].each do |version|
       @session.http_version = version
       response = @session.get("/test")
       expect(response.status).to be == 200


### PR DESCRIPTION
Added support for ssl_version options "TLSv1_0", "TLSv1_1", "TLSv1_2", and "TLSv1_3" with preprocessor sections to allow compilation on systems with older versions of libCURL

Added new option http_version and options "None", "HTTPv1_0", "HTTPv1_1", "HTTPv2_0", "HTTPv2_TLS", and "HTTPv2_PRIOR" with preprocessor sections to allow compilation on systems with older versions of libCURL. 

Added associated error/exceptions for http_version based on the errors for ssl_version.

Ubuntu 16.04 comes with libcurl v7.47.0 tested with that version and the latest 7.54.0

Tested with both versions
"POST /users HTTP/2.0" 200 148 "-" "Patron/Ruby-0.8.0-libcurl/7.54.0 OpenSSL/1.1.0e zlib/1.2.8 nghttp2/1.23.0-DEV librtmp/2.3"