### PR TITLE
Update the gem release procedure and gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
+
+# Specify your gem's dependencies in patron.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,11 +36,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 1.0.0)
+  bundler (>= 1)
   patron!
-  rake-compiler (>= 0.7.5)
+  rake (~> 10)
+  rake-compiler
   rspec (>= 2.3.0)
-  simplecov (~> 0.12)
+  simplecov (~> 0.10)
   yard (~> 0.8)
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -24,16 +24,18 @@
 require 'rake/clean'
 require 'rake/extensiontask'
 require 'rspec/core/rake_task'
-require 'bundler'
+require "bundler/gem_tasks"
 require 'yard'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :build => :compile
 
 Rake::ExtensionTask.new do |ext|
   ext.name = 'session_ext'           # indicate the name of the extension.
   ext.ext_dir = 'ext/patron'         # search for 'hello_world' inside it.
   ext.lib_dir = 'lib/patron'         # put binaries into this folder.
 end
-
-Bundler::GemHelper.install_tasks
 
 CLEAN.include FileList["ext/patron/*"].exclude(/^.*\.(rb|c|h)$/)
 CLOBBER.include %w( doc coverage pkg )
@@ -50,12 +52,4 @@ YARD::Rake::YardocTask.new do |t|
   t.stats_options = ['--list-undoc']
 end
 
-desc "Run specs"
-RSpec::Core::RakeTask.new do |t|
-  t.rspec_opts = %w( --colour --format progress )
-  t.pattern = 'spec/**/*_spec.rb'
-end
-
-task :spec => [:compile]
-
-task :default => :spec
+task :default => [:clobber, :compile, :spec]

--- a/patron.gemspec
+++ b/patron.gemspec
@@ -1,33 +1,44 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path("../lib/patron/version", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'patron/version'
 
-Gem::Specification.new do |s|
-  s.name        = "patron"
-  s.version     = Patron::VERSION
-  s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Phillip Toland"]
-  s.email       = ["phil.toland@gmail.com"]
-  s.homepage    = "https://github.com/toland/patron"
-  s.summary     = "Patron HTTP Client"
-  s.description = "Ruby HTTP client library based on libcurl"
+Gem::Specification.new do |spec|
+  spec.name        = "patron"
+  spec.version     = Patron::VERSION
+  spec.platform    = Gem::Platform::RUBY
+  spec.authors     = ["Phillip Toland"]
+  spec.email       = ["phil.toland@gmail.com"]
+  spec.homepage    = "https://github.com/toland/patron"
+  spec.summary     = "Patron HTTP Client"
+  spec.description = "Ruby HTTP client library based on libcurl"
 
-  s.required_rubygems_version = ">= 1.2.0"
-  s.rubyforge_project = "patron"
+  # Prevent pushing this gem to RubyGemspec.org. To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = "https://rubygemspec.org"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against public gem pushespec."
+  end
+  
+  spec.required_rubygems_version = ">= 1.2.0"
+  spec.rubyforge_project = "patron"
 
-  s.add_development_dependency "bundler", ">= 1.0.0"
-  s.add_development_dependency "rake-compiler", ">= 0.7.5"
-  s.add_development_dependency "rspec", ">= 2.3.0"
-  s.add_development_dependency "simplecov", "~> 0.12"
-  s.add_development_dependency "yard", "~> 0.8"
-
-  s.files        = `git ls-files`.split("\n")
-  s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
-  s.require_paths = ["lib", "ext"]
-  s.extensions   = ["ext/patron/extconf.rb"]
-  s.post_install_message = %q{
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib", "ext"]
+  spec.extensions   = ["ext/patron/extconf.rb"]
+  spec.post_install_message = %q{
 Thank you for installing Patron. On OSX, make sure you are using libCURL with OpenSSL.
-SecureTransport-based builds might cause crashes in forking environments.
+SecureTransport-based builds might cause crashes in forking environment.
 
 For more info see https://github.com/curl/curl/issues/788
 }
+  spec.add_development_dependency "rake", "~> 10"
+  spec.add_development_dependency "bundler", ">= 1"
+  spec.add_development_dependency "rspec", ">= 2.3.0"
+  spec.add_development_dependency "simplecov", "~> 0.10"
+  spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency "rake-compiler"
 end


### PR DESCRIPTION
Use the latest Bundler/Rubygems features to automate releases.

Once this is applied, all it takes to release Patron is this command:

```
$ bundle exec rake release
```

No dependencies get introduced except for the updated Bundler requirements.
Closes #137 