### PR TITLE
Make Patron Ruby 2.4.1 ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm:
 - 2.1.5
 - 2.2.2
 - 2.3.0
+- 2.4.1
 sudo: false
 cache: bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   specs:
     diff-lcs (1.2.5)
     docile (1.1.5)
-    json (1.8.3)
+    json (2.1.0)
     rake (10.4.2)
     rake-compiler (0.9.5)
       rake
@@ -25,11 +25,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    simplecov (0.10.0)
+    simplecov (0.14.1)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.1)
     yard (0.8.7.6)
 
 PLATFORMS
@@ -40,8 +40,8 @@ DEPENDENCIES
   patron!
   rake-compiler (>= 0.7.5)
   rspec (>= 2.3.0)
-  simplecov (>= 0.10.0)
+  simplecov (~> 0.12)
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/lib/patron/response.rb
+++ b/lib/patron/response.rb
@@ -33,13 +33,13 @@ module Patron
     # @return [String] the original URL used to perform the request (contains the final URL after redirects)
     attr_reader :url
 
-    # @return [Fixnum] the HTTP status code of the final response after all the redirects
+    # @return [Integer] the HTTP status code of the final response after all the redirects
     attr_reader :status
 
     # @return [String] the complete status line (code and message)
     attr_reader :status_line
 
-    # @return [Fixnum] how many redirects were followed when fulfilling this request
+    # @return [Integer] how many redirects were followed when fulfilling this request
     attr_reader :redirect_count
 
     # @return [String, nil] the response body as a String encoded as `Encoding::BINARY` or

--- a/patron.gemspec
+++ b/patron.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake-compiler", ">= 0.7.5"
   s.add_development_dependency "rspec", ">= 2.3.0"
-  s.add_development_dependency "simplecov", ">= 0.10.0"
+  s.add_development_dependency "simplecov", "~> 0.12"
   s.add_development_dependency "yard", "~> 0.8"
 
   s.files        = `git ls-files`.split("\n")

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -45,7 +45,7 @@ describe Patron::Response do
 
   it 'recovers the status code' do
     response = @session.get("/repetitiveheader")
-    expect(response.status).to be_kind_of(Fixnum)
+    expect(response.status).to be_kind_of(Integer)
     expect(response.status).to eq(200)
   end
   


### PR DESCRIPTION
It worked apparently, but this codifies the fact. Adds 2.4.1 to Travis,
changes Fixnum assertions/documentation to Integers, and updates Simplecov
to a version with a compatible JSON extension