### PR TITLE
Add libcurl_version_exact for fetching version

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -207,6 +207,20 @@ static VALUE libcurl_version(VALUE klass) {
 }
 
 /*
+* Returns the version of the embedded libcurl.
+* 
+*  @return [Array] an array of MAJOR, MINOR, PATCH integers
+ */
+static VALUE libcurl_version_exact(VALUE klass) {
+  UNUSED_ARGUMENT(klass);
+  VALUE cv_major = INT2FIX(LIBCURL_VERSION_MAJOR);
+  VALUE cv_minor = INT2FIX(LIBCURL_VERSION_MINOR);
+  VALUE cv_patch = INT2FIX(LIBCURL_VERSION_PATCH);
+  VALUE version_arr = rb_ary_new3(3, cv_major, cv_minor, cv_patch);
+  return version_arr;
+}
+
+/*
  * Escapes the provided string using libCURL URL escaping functions.
  *
  * @param [String] value plain string to URL-escape
@@ -833,7 +847,8 @@ void Init_session_ext() {
   eTimeoutError = rb_const_get(mPatron, rb_intern("TimeoutError"));
   eTooManyRedirects = rb_const_get(mPatron, rb_intern("TooManyRedirects"));
 
-  rb_define_module_function(mPatron, "libcurl_version", libcurl_version, 0);
+  rb_define_module_function(mPatron, "libcurl_version",       libcurl_version, 0);
+  rb_define_module_function(mPatron, "libcurl_version_exact", libcurl_version_exact, 0);
 
   cSession = rb_define_class_under(mPatron, "Session", rb_cObject);
   cRequest = rb_define_class_under(mPatron, "Request", rb_cObject);

--- a/spec/patron_spec.rb
+++ b/spec/patron_spec.rb
@@ -38,9 +38,16 @@ describe Patron do
     expect(version).to match(%r|^\d+.\d+.\d+$|)
   end
 
-  it "should return the version number of the libcurl library" do
+  it "should return the version string of the libcurl library" do
     version = Patron.libcurl_version
     expect(version).to match(%r|^libcurl/\d+.\d+.\d+|)
   end
 
+  it "should return the version numbers of the libcurl library" do
+    version = Patron.libcurl_version_exact
+    expect(version.length).to eq(3)
+    expect(version[0]).to be > 0
+    expect(version[1]).to be >= 0
+    expect(version[2]).to be >= 0
+  end
 end


### PR DESCRIPTION
More and more options in Patron depend on the specific CURL features
being available, and that is version dependent. The current libcurl_version
method does not provide something that's easily machine-usable or comparable,
and since these values are available in the included headers we might as well
use them.

Another option would be to use `Gem::Version` but I am not certain libCURL
version semantics are the same as gem version semantics, and then you need
your own comparison operator and so forth. Yet another would be to reuse the CURL_VERSION_NUMERIC define, but it needs bit-twiddling to extract the major/minor/patch versions which is not something very Ruby-esque.