### PR TITLE
Add support for PROPFIND action

### DIFF
--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -34,7 +34,7 @@ module Patron
   class Request
 
     # Contains the valid HTTP verbs that can be used to perform requests
-    VALID_ACTIONS = %w[GET PUT POST DELETE HEAD COPY PATCH]
+    VALID_ACTIONS = %w[GET PUT POST DELETE HEAD COPY PATCH PROPFIND]
 
     # Initializes a new Request, which defaults to the GET HTTP verb and
     # has it's timeouts set to 0
@@ -133,7 +133,7 @@ module Patron
 
       @connect_timeout = new_timeout.to_i
     end
-    
+
     # Sets the maximum number of redirects that are going to be followed.
     #
     # @param new_max_redirects[Integer] The number of redirects to follow, or `-1` for unlimited redirects.

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -55,7 +55,7 @@ module Patron
     # Username for http authentication
     # @return [String,nil] the HTTP basic auth username
     attr_accessor :username
-    
+
     # Password for http authentication
     # @return [String,nil] the HTTP basic auth password
     attr_accessor :password
@@ -103,7 +103,7 @@ module Patron
     # response does not specify a charset in it's `Content-Type` header already, if it does that charset
     # will take precedence.
     attr_accessor :default_response_charset
-    
+
     # @return [Boolean] Force curl to use IPv4
     attr_accessor :force_ipv4
 
@@ -152,7 +152,7 @@ module Patron
     def handle_cookies(file_path = nil)
       if file_path
         path = Pathname(file_path).expand_path
-        
+
         if !File.exists?(file_path) && !File.writable?(path.dirname)
           raise ArgumentError, "Can't create file #{path} (permission error)"
         elsif File.exists?(file_path) && !File.writable?(file_path)
@@ -161,12 +161,12 @@ module Patron
       else
         path = nil
       end
-      
+
       # Apparently calling this with an empty string sets the cookie file,
       # but calling it with a path to a writable file sets that file to be
       # the cookie jar (new cookies are written there)
       add_cookie_file(path.to_s)
-      
+
       self
     end
 
@@ -259,6 +259,17 @@ module Patron
       request(:patch, url, headers, :data => data)
     end
 
+    # Same as #get but performs a PROPFIND request.
+    #
+    # Notice: this method doesn't accept any `data` argument
+    #
+    # @param url[String] the URL to fetch
+    # @param headers[Hash] the hash of header keys to values
+    # @return [Patron::Response]
+    def propfind(url, headers = {})
+      request(:propfind, url, headers)
+    end
+
     # Uploads the contents of `file` to the specified `url` using an HTTP PUT. The file will be
     # sent "as-is" without any multipart encoding.
     #
@@ -322,7 +333,7 @@ module Patron
       request(:copy, url, headers)
     end
     # @!endgroup
-    
+
     # @!group Basic API methods
     # Send an HTTP request to the specified `url`.
     #
@@ -336,7 +347,7 @@ module Patron
       req = build_request(action, url, headers, options)
       handle_request(req)
     end
-    
+
     # Returns the class that will be used to build a Response
     # from a Curl call.
     #
@@ -351,7 +362,7 @@ module Patron
     def response_class
       ::Patron::Response
     end
-    
+
     # Builds a request object that can be used by ++handle_request++
     # Note that internally, ++handle_request++ uses instance variables of
     # the Request object, and not it's public methods.

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -34,8 +34,8 @@ describe Patron::Request do
 
   describe :action do
 
-    it "should accept :get, :put, :post, :delete and :head" do
-      [:get, :put, :post, :delete, :head, :copy].each do |action|
+    it "should accept :get, :put, :post, :delete, :head, :copy, :patch and :propfind" do
+      [:get, :put, :post, :delete, :head, :copy, :patch, :propfind].each do |action|
         expect {@request.action = action}.not_to raise_error
       end
     end

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -71,21 +71,25 @@ class TestServlet < HTTPServlet::AbstractServlet
   def do_COPY(req,res)
     respond_with(:COPY, req, res)
   end
+
+  def do_PROPFIND(req,res)
+    respond_with(:PROPFIND, req, res)
+  end
 end
 
 class GzipServlet < HTTPServlet::AbstractServlet
 
   def do_GET(req,res)
     raise "Need to have the right Accept-Encoding: header" unless req.header['Accept-Encoding']
-    
+
     out = StringIO.new
     z = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION)
-    1024.times { 
+    1024.times {
       out << z.deflate('Some highly compressible data')
     }
     out << z.finish
     z.close
-    
+
     content_length = out.size
     # Content-Length gets set automatically by WEBrick, and if we do it manually
     # here then two headers will be set.
@@ -234,4 +238,3 @@ class PatronTestServer
     self
   end
 end
-


### PR DESCRIPTION
When trying to use `PROPFIND` HTTP verb I realized that `Patron` doesn't support it. Is there a reason for that? By the way, can you consider merging this one? Any suggestions are welcome :smile: 