### PR TITLE
Add support for LOW_SPEED_TIME and LOW_SPEED_LIMIT

### DIFF
--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -547,6 +547,16 @@ static void set_options_from_request(VALUE self, VALUE request) {
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, FIX2INT(timeout));
   }
 
+  VALUE low_speed_time = rb_funcall(request, rb_intern("low_speed_time"), 0);
+  if(RTEST(low_speed_time)) {
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, FIX2LONG(low_speed_time));
+  }
+
+  VALUE low_speed_limit_bytes_per_second = rb_funcall(request, rb_intern("low_speed_limit"), 0);
+  if(RTEST(low_speed_limit_bytes_per_second)) {
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, FIX2LONG(low_speed_limit_bytes_per_second));
+  }
+
   redirects = rb_funcall(request, rb_intern("max_redirects"), 0);
   if (RTEST(redirects)) {
     int r = FIX2INT(redirects);

--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -24,12 +24,14 @@ module Patron
       :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
       :ignore_content_length, :multipart, :action, :timeout, :connect_timeout,
       :max_redirects, :headers, :auth_type, :upload_data, :buffer_size, :cacert,
-      :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4, :download_byte_limit
+      :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4, :download_byte_limit,
+      :low_speed_time, :low_speed_limit
     ]
 
     WRITER_VARS = [
       :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
-      :ignore_content_length, :multipart, :cacert, :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4, :download_byte_limit
+      :ignore_content_length, :multipart, :cacert, :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4, :download_byte_limit,
+      :low_speed_time, :low_speed_limit
     ]
 
     attr_reader *READER_VARS

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -84,10 +84,20 @@ module Patron
     # @return [Boolean] Support automatic Content-Encoding decompression and set liberal Accept-Encoding headers
     attr_accessor :automatic_content_encoding
 
-    # @return [Fixnum, nil] Limit the amount of bytes downloaded. If it is set to nil
+    # @return [Fixnum, nil] the amount of bytes downloaded. If it is set to nil
     #    (default) no limit will be applied.
     #    **Note that this only works on libCURL 7.34 and newer**
     attr_accessor :download_byte_limit
+
+    # @return [Integer, nil] the time in number seconds that the transfer speed should be below the
+    #     `low_speed_limit` for the library to consider it too slow and abort.
+    # @see low_speed_limit
+    attr_accessor :low_speed_time
+
+    # @return [Integer, nil] the average transfer speed in bytes per second that the transfer should be below
+    #    during `low_speed_time` seconds for libcurl to consider it to be too slow and abort.
+    # @see low_speed_time
+    attr_accessor :low_speed_limit
 
     private :handle_request, :add_cookie_file, :set_debug_file
 
@@ -345,6 +355,8 @@ module Patron
         req.automatic_content_encoding = options.fetch :automatic_content_encoding, self.automatic_content_encoding
         req.timeout                = options.fetch :timeout,               self.timeout
         req.connect_timeout        = options.fetch :connect_timeout,       self.connect_timeout
+        req.low_speed_time         = options.fetch :low_speed_time,        self.low_speed_time
+        req.low_speed_limit        = options.fetch :low_speed_limit,       self.low_speed_limit
         req.force_ipv4             = options.fetch :force_ipv4,            self.force_ipv4
         req.max_redirects          = options.fetch :max_redirects,         self.max_redirects
         req.username               = options.fetch :username,              self.username

--- a/lib/patron/version.rb
+++ b/lib/patron/version.rb
@@ -1,3 +1,3 @@
 module Patron
-  VERSION = "0.9.1"
+  VERSION = "0.10.0"
 end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -171,6 +171,13 @@ describe Patron::Session do
     expect {@session.get("/timeout")}.to raise_error(Patron::TimeoutError)
   end
 
+  it "should raise an exception on timeout when reading from a slow resource" do
+    @session.timeout = 40
+    @session.low_speed_time = 2
+    @session.low_speed_limit = 10
+    expect {@session.get("/slow")}.to raise_error(Patron::TimeoutError)
+  end
+
   it "should follow redirects by default" do
     @session.max_redirects = 1
     response = @session.get("/redirect")

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -80,6 +80,14 @@ class TimeoutServlet < HTTPServlet::AbstractServlet
   end
 end
 
+class SlowServlet < HTTPServlet::AbstractServlet
+  def do_GET(req,res)
+    sleep 3
+    res.header['Content-Type'] = 'text/plain'
+    res.body = 'beep'
+  end
+end
+
 class RedirectServlet < HTTPServlet::AbstractServlet
   def do_GET(req,res)
     res['Location'] = "http://localhost:9001/test"
@@ -181,6 +189,7 @@ class PatronTestServer
     @server.mount("/testpost", TestPostBodyServlet)
     @server.mount("/testpatch", TestPatchBodyServlet)
     @server.mount("/timeout", TimeoutServlet)
+    @server.mount("/slow", SlowServlet)
     @server.mount("/redirect", RedirectServlet)
     @server.mount("/evil-redirect", EvilRedirectServlet)
     @server.mount("/picture", PictureServlet)


### PR DESCRIPTION
These permit libCURL to time out early if the socket is starved.
This is useful for setting timeouts based on the expected response
size, as opposed to configuring one hard read timeout for the
entire response receive time stretch. For instance, with a read
timeout, you would need to set a value that works equally well
for a 5MB download as well as for a 50MB download.

These two CURLOPTs permit timeouts based on speed as well.