### PR TITLE
Add Ruby progress callback + customise our GIL unblock function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Added `Session#progress_callback` which accepts a callable object, which can be used to report session progress during request
+  execution.
+
 ### 0.10.0
 
 * Added `Session#low_speed_time` and `Session#low_speed_limit`. When used, they will force libCURL to raise

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -105,7 +105,7 @@ static int session_progress_handler(void* clientp, size_t dltotal, size_t dlnow,
 
 //  rb_thread_check_ints();
 //  rb_thread_call_with_gvl((void *(*)(void *)) call_rb_progress_blk, (void*)state);
-  rb_thread_call_with_gvl(rb_thread_check_ints, NULL);
+//  rb_thread_call_with_gvl(rb_thread_check_ints, NULL);
 
   // Set the interrupt if the download byte limit has been reached
   if(state->download_byte_limit != 0 && (dltotal > state->download_byte_limit)) {

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -794,17 +794,17 @@ static VALUE perform_request(VALUE self) {
   }
 
 #if (defined(HAVE_TBR) || defined(HAVE_TCWOGVL)) && defined(USE_TBR)
-#if defined(HAVE_TCWOGVL)
-  ret = (CURLcode) rb_thread_call_without_gvl2(
-          (void *(*)(void *)) curl_easy_perform, curl,
-          session_ubf_abort, (void*)state
-        );
-#else
-  ret = (CURLcode) rb_thread_blocking_region(
-          (rb_blocking_function_t*) curl_easy_perform, curl,
-          session_ubf_abort, (void*)state
-        );
-#endif
+  #if defined(HAVE_TCWOGVL)
+    ret = (CURLcode) rb_thread_call_without_gvl(
+            (void *(*)(void *)) curl_easy_perform, curl,
+            session_ubf_abort, (void*)state
+          );
+  #else
+    ret = (CURLcode) rb_thread_blocking_region(
+            (rb_blocking_function_t*) curl_easy_perform, curl,
+            session_ubf_abort, (void*)state
+          );
+  #endif
 #else
   ret = curl_easy_perform(curl);
 #endif

--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -78,11 +78,6 @@ module Patron
       end
     end
 
-    def progress_callback
-      nil
-#      Proc.new{|*a| $stderr.puts a.inspect }
-    end
-
     # Sets the HTTP verb for the request
     #
     # @param action[String] the name of the HTTP verb

--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -25,13 +25,13 @@ module Patron
       :ignore_content_length, :multipart, :action, :timeout, :connect_timeout,
       :max_redirects, :headers, :auth_type, :upload_data, :buffer_size, :cacert,
       :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4, :download_byte_limit,
-      :low_speed_time, :low_speed_limit
+      :low_speed_time, :low_speed_limit, :progress_callback
     ]
 
     WRITER_VARS = [
       :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
       :ignore_content_length, :multipart, :cacert, :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4, :download_byte_limit,
-      :low_speed_time, :low_speed_limit
+      :low_speed_time, :low_speed_limit, :progress_callback
     ]
 
     attr_reader *READER_VARS
@@ -76,6 +76,11 @@ module Patron
       else
         data
       end
+    end
+
+    def progress_callback
+      nil
+#      Proc.new{|*a| $stderr.puts a.inspect }
     end
 
     # Sets the HTTP verb for the request

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -101,6 +101,7 @@ module Patron
 
     private :handle_request, :add_cookie_file, :set_debug_file
 
+    attr_accessor :progress_callback
     # Create a new Session object for performing requests.
     #
     # @param args[Hash] options for the Session (same names as the writable attributes of the Session)
@@ -371,6 +372,7 @@ module Patron
         req.ignore_content_length  = options.fetch :ignore_content_length, self.ignore_content_length
         req.buffer_size            = options.fetch :buffer_size,           self.buffer_size
         req.download_byte_limit    = options.fetch :download_byte_limit,   self.download_byte_limit
+        req.progress_callback      = options.fetch :progress_callback,     self.progress_callback
         req.multipart              = options[:multipart]
         req.upload_data            = options[:data]
         req.file_name              = options[:file]

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -101,7 +101,11 @@ module Patron
 
     private :handle_request, :add_cookie_file, :set_debug_file
 
+    # @return [#call, nil] callable object that will be called with 4 arguments
+    #    during request/response execution - `dltotal`, `dlnow`, `ultotal`, `ulnow`.
+    #    All these arguments are in bytes.
     attr_accessor :progress_callback
+
     # Create a new Session object for performing requests.
     #
     # @param args[Hash] options for the Session (same names as the writable attributes of the Session)

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -178,6 +178,47 @@ describe Patron::Session do
     expect {@session.get("/slow")}.to raise_error(Patron::TimeoutError)
   end
 
+  it "is able to terminate the thread that is running a slow request" do
+    Thread.abort_on_exception = true
+    t = Thread.new do
+      session = Patron::Session.new
+      session.timeout = 40
+      session.base_url = "http://localhost:9001"
+      session.get("/slow")
+    end
+    sleep 12
+    t.kill
+  end
+
+  it "is able to terminate the thread that is running a slow request" do
+    t = Thread.new do
+      session = Patron::Session.new
+      session.timeout = 40
+      session.base_url = "http://localhost:9001"
+      session.get("/slow")
+    end
+    sleep 3
+    t.kill
+  end
+
+  it "is able to terminate the thread that is running a slow request" do
+    t = Thread.new do
+      session = Patron::Session.new
+      session.timeout = 40
+      session.base_url = "http://localhost:9001"
+      session.get("/slow")
+    end
+    sleep 10
+    t.join
+  end
+
+  it "is able to terminate main thread that is running a slow request" do
+    session = Patron::Session.new
+    session.timeout = 40
+    session.base_url = "http://localhost:9001"
+    session.get("/slow")
+  end
+
   it "should follow redirects by default" do
     @session.max_redirects = 1
     response = @session.get("/redirect")

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -178,33 +178,44 @@ describe Patron::Session do
     expect {@session.get("/slow")}.to raise_error(Patron::TimeoutError)
   end
 
-  it "is able to terminate the thread that is running a slow request" do
+  it "is able to terminate the thread that is running a slow request using Thread#kill (uses the custom unblock)" do
     t = Thread.new do
       session = Patron::Session.new
       session.timeout = 40
       session.base_url = "http://localhost:9001"
       session.get("/slow")
     end
-    sleep 3
-    t.kill
+
+    # Our test server starts sending the body only after 20 seconds. We should be able to abort
+    # using a signal during that time.
+    started = Time.now.to_i
+    sleep 5 # Less than what it takes for the server to respond
+    t.kill # Kill the thread forcibly
+    t.join # wrap up the thread. If Patron is still busy there, this join call will still take 15s.
+
+    delta_s = Time.now.to_i - started
+    expect(delta_s).to be_within(2).of(5)
   end
 
   it "is able to terminate the thread that is running a slow request" do
     t = Thread.new do
+      trap('SIGINT') do
+        exit # exit the thread
+      end
       session = Patron::Session.new
       session.timeout = 40
       session.base_url = "http://localhost:9001"
       session.get("/slow")
     end
-    sleep 10
-    t.join
-  end
 
-  it "is able to terminate main thread that is running a slow request" do
-    session = Patron::Session.new
-    session.timeout = 40
-    session.base_url = "http://localhost:9001"
-    session.get("/slow")
+    # Our test server starts sending the body only after 20 seconds. We should be able to abort
+    # using a signal during that time.
+    started = Time.now.to_i
+    sleep 5 # Less than what it takes for the server to respond
+    Process.kill("INT", Process.pid) # Signal ourselves...
+    t.join # wrap up the thread. If Patron is still busy there, this join call will still take 15s.
+    delta_s = Time.now.to_i - started
+    expect(delta_s).to be_within(2).of(5)
   end
 
   it "should follow redirects by default" do

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -218,6 +218,19 @@ describe Patron::Session do
     expect(delta_s).to be_within(2).of(5)
   end
 
+  it "receives progress callbacks" do
+    session = Patron::Session.new
+    session.timeout = 40
+    session.base_url = "http://localhost:9001"
+    callback_args = []
+    session.progress_callback = Proc.new {|dltotal, dlnow, ultotal, ulnow|
+      callback_args << [dltotal, dlnow, ultotal, ulnow]
+    }
+    session.get("/slow")
+
+    expect(callback_args).not_to be_empty
+  end
+
   it "should follow redirects by default" do
     @session.max_redirects = 1
     response = @session.get("/redirect")

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -179,18 +179,6 @@ describe Patron::Session do
   end
 
   it "is able to terminate the thread that is running a slow request" do
-    Thread.abort_on_exception = true
-    t = Thread.new do
-      session = Patron::Session.new
-      session.timeout = 40
-      session.base_url = "http://localhost:9001"
-      session.get("/slow")
-    end
-    sleep 12
-    t.kill
-  end
-
-  it "is able to terminate the thread that is running a slow request" do
     t = Thread.new do
       session = Patron::Session.new
       session.timeout = 40

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -82,7 +82,7 @@ end
 
 class SlowServlet < HTTPServlet::AbstractServlet
   def do_GET(req,res)
-    sleep 3
+    sleep 15
     res.header['Content-Type'] = 'text/plain'
     res.body = 'beep'
   end

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -202,13 +202,13 @@ class PatronTestServer
   end
 
   def start
-#    trap('INT') {
-#      begin
-#        @server.shutdown unless @server.nil?
-#      rescue Object => e
-#        $stderr.puts "Error #{__FILE__}:#{__LINE__}\n#{e.message}"
-#      end
-#    }
+    trap('INT') {
+      begin
+        @server.shutdown unless @server.nil?
+      rescue Object => e
+        $stderr.puts "Error #{__FILE__}:#{__LINE__}\n#{e.message}"
+      end
+    }
 
     @thread = Thread.new { @server.start }
     Thread.pass

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -82,9 +82,10 @@ end
 
 class SlowServlet < HTTPServlet::AbstractServlet
   def do_GET(req,res)
-    sleep 15
     res.header['Content-Type'] = 'text/plain'
-    res.body = 'beep'
+    res.body << 'x'
+    sleep 20
+    res.body << 'rest of body'
   end
 end
 
@@ -201,13 +202,13 @@ class PatronTestServer
   end
 
   def start
-    trap('INT') {
-      begin
-        @server.shutdown unless @server.nil?
-      rescue Object => e
-        $stderr.puts "Error #{__FILE__}:#{__LINE__}\n#{e.message}"
-      end
-    }
+#    trap('INT') {
+#      begin
+#        @server.shutdown unless @server.nil?
+#      rescue Object => e
+#        $stderr.puts "Error #{__FILE__}:#{__LINE__}\n#{e.message}"
+#      end
+#    }
 
     @thread = Thread.new { @server.start }
     Thread.pass


### PR DESCRIPTION
We should provide some ability for users to re-acquire the GIL and call Ruby callback blocks. We will start with a progress callback which can be used for progress bars and speed computation. We also need to alter the way we unblock the thread so that we correctly handle signals.

This adds the following API:

```
sess.progress_callback = ->(download_total, download_now, upload_total, upload_now) {
  progress_bar.update(download_total) # ...or other interesting actions
}
```

The GIL will only be reacquired if this is configured on the Session/Request objects, otherwise we proceed through the same fast path as before with the GIL unlocked.

Closes #150 and paves the way for making #139 possible