### PR TITLE
Correctly parse headers from multiple responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed parsing of response headers when multiple responses are involved (redirect chains and HTTP proxies)
+
 ### 0.10.0
 
 * Added `Session#low_speed_time` and `Session#low_speed_limit`. When used, they will force libCURL to raise

--- a/lib/patron/header_parser.rb
+++ b/lib/patron/header_parser.rb
@@ -1,0 +1,32 @@
+module Patron::HeaderParser
+  CRLF = /#{Regexp.escape("\r\n")}/
+
+  # Returned for each response parsed out
+  class SingleResponseHeaders < Struct.new(:status_line, :headers)
+  end
+
+  # Parses a string with lines delimited with CRLF into
+  # an Array of SingleResponseHeaders objects. libCURL supplies
+  # us multiple responses in sequence, so if we encounter multiple redirect
+  # or operate through a proxy - that adds ConnectionEstablished status at
+  # the beginning of the response - we need to account for parsing
+  # multiple response headres and potentially preserving them.
+  #
+  # @param [String] the string of headers, with responses delimited by empty lines. All lines must end with CRLF
+  # @return Array<SingleResponseHeaders>
+  def self.parse(headers_from_multiple_responses_in_sequence)
+    s = StringScanner.new(headers_from_multiple_responses_in_sequence)
+    responses = []
+    until s.eos?
+      return unless scanned = s.scan_until(CRLF)
+      matched_line = scanned[0..-3]
+      if matched_line =~ /^HTTP\/\d\.\d \d+/
+        responses << SingleResponseHeaders.new(matched_line.strip, [])
+      elsif matched_line =~ /^[^:]+\:/
+        raise "Header should follow an HTTP status line" unless responses.any?
+        responses[-1].headers << matched_line
+      end # else it is the end of the headers for the request
+    end
+    responses
+  end
+end

--- a/lib/patron/response.rb
+++ b/lib/patron/response.rb
@@ -113,16 +113,14 @@ module Patron
     private
 
     # Called by the C code to parse and set the headers
-    def parse_headers(header_data)
+    def parse_headers(header_data_for_multiple_responses)
       @headers = {}
 
-      lines = header_data.split("\r\n")
+      responses = Patron::HeaderParser.parse(header_data_for_multiple_responses)
+      last_response = responses[-1] # Only use the last response (for proxies and redirects)
 
-      @status_line = lines.shift
-
-      lines.each do |line|
-        break if line.empty?
-
+      @status_line = last_response.status_line
+      last_response.headers.each do |line|
         hdr, val = line.split(":", 2)
 
         val.strip! unless val.nil?

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -5,6 +5,7 @@ require 'patron/response_decoding'
 require 'patron/response'
 require 'patron/session_ext'
 require 'patron/util'
+require 'patron/header_parser'
 
 module Patron
 

--- a/spec/header_parser_spec.rb
+++ b/spec/header_parser_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe Patron::HeaderParser do
+  it 'parses a standard header' do
+    simple_headers_path = File.dirname(__FILE__) + '/sample_response_headers/headers_wetransfer.txt'
+    responses = Patron::HeaderParser.parse(File.read(simple_headers_path))
+
+    expect(responses.length).to eq(1)
+    first_response = responses[0]
+    expect(first_response.status_line).to eq("HTTP/1.1 200 OK")
+    expect(first_response.headers).to be_kind_of(Array)
+    expect(first_response.headers[0]).to eq("Date: Mon, 29 Jan 2018 00:09:09 GMT")
+    expect(first_response.headers[1]).to eq("Content-Type: text/html; charset=utf-8")
+    expect(first_response.headers[2]).to eq("Transfer-Encoding: chunked")
+    expect(first_response.headers[3]).to eq("Connection: keep-alive")
+  end
+
+  it 'parses a sequence of responses resulting from a redirect' do
+    simple_headers_path = File.dirname(__FILE__) + '/sample_response_headers/headers_wetransfer_with_redirect.txt'
+    responses = Patron::HeaderParser.parse(File.read(simple_headers_path))
+
+    expect(responses.length).to eq(2)
+    first_response = responses[0]
+
+    expect(first_response.status_line).to eq("HTTP/1.1 301 Moved Permanently")
+    expect(first_response.headers).to be_kind_of(Array)
+    expect(first_response.headers[0]).to eq("Date: Mon, 29 Jan 2018 00:42:27 GMT")
+    expect(first_response.headers[2]).to eq("Connection: keep-alive")
+    expect(first_response.headers[3]).to eq("Location: https://wetransfer.com/")
+    expect(first_response.headers[4]).to be_nil
+
+    second_response = responses[1]
+    expect(second_response.status_line).to eq("HTTP/1.1 200 OK")
+    expect(second_response.headers).to be_kind_of(Array)
+    expect(second_response.headers[0]).to eq("Date: Mon, 29 Jan 2018 00:42:27 GMT")
+    expect(second_response.headers[1]).to eq("Content-Type: text/html; charset=utf-8")
+    expect(second_response.headers[2]).to eq("Transfer-Encoding: chunked")
+  end
+
+  it 'parses response headers that set cookies' do
+    simple_headers_path = File.dirname(__FILE__) + '/sample_response_headers/headers_with_set_cookie.txt'
+    responses = Patron::HeaderParser.parse(File.read(simple_headers_path))
+
+    expect(responses.length).to eq(1)
+    first_response = responses[0]
+
+    expect(first_response.status_line).to eq("HTTP/1.1 200 OK")
+    expect(first_response.headers).to be_kind_of(Array)
+    expect(first_response.headers[0]).to eq("Content-Type: text/plain")
+    expect(first_response.headers[1]).to start_with('Server:')
+    expect(first_response.headers[2]).to eq("Date: Mon, 29 Jan 2018 01:50:54 GMT")
+    expect(first_response.headers[3]).to eq("Content-Length: 3")
+    expect(first_response.headers[4]).to eq("Connection: Keep-Alive")
+    expect(first_response.headers[5]).to eq("Set-Cookie: a=1")
+  end
+
+  it 'parses response headers with an extra status line from a proxy' do
+    simple_headers_path = File.dirname(__FILE__) + '/sample_response_headers/headers_wetransfer_with_proxy_status.txt'
+    responses = Patron::HeaderParser.parse(File.read(simple_headers_path))
+
+    expect(responses.length).to eq(2)
+    first_response = responses[0]
+
+    expect(first_response.status_line).to eq("HTTP/1.1 200 Connection established")
+    expect(first_response.headers).to be_kind_of(Array)
+    expect(first_response.headers).to be_empty
+
+    second_response = responses[1]
+    expect(second_response.status_line).to eq("HTTP/1.1 200 OK")
+    expect(second_response.headers).to be_kind_of(Array)
+    expect(second_response.headers[0]).to eq("Date: Mon, 29 Jan 2018 00:09:09 GMT")
+  end
+end

--- a/spec/sample_response_headers/headers_wetransfer.txt
+++ b/spec/sample_response_headers/headers_wetransfer.txt
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+Date: Mon, 29 Jan 2018 00:09:09 GMT
+Content-Type: text/html; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: Fri, 01 Jan 1990 00:00:00 GMT
+Vary: Accept-Encoding, Origin
+Set-Cookie: _wt_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTllOGNkZDg3N2Y2Mzc2M2E1NWY2NTQwMjYzNzljODJhBjsAVEkiEF9jc3JmX3Rva2VuBjsARkkiMXk4YWtnZDVNYlRYUmJJWkFFaWkzVXFWM3IzbE1aU2xSbFl3SDQ3aHArbU09BjsARg%3D%3D--fe13900e81f693acb4a80d372d864c78704fa776; domain=wetransfer.com; path=/; secure; HttpOnly
+X-Request-Id: 62b0d737-b0f8-400b-ac3a-0f84acf241af
+X-Opaque: dev-1.wt-19171
+X-Runtime: 0.116529
+Strict-Transport-Security: max-age=15552000; includeSubDomains;
+

--- a/spec/sample_response_headers/headers_wetransfer_with_proxy_status.txt
+++ b/spec/sample_response_headers/headers_wetransfer_with_proxy_status.txt
@@ -1,0 +1,20 @@
+HTTP/1.1 200 Connection established
+
+HTTP/1.1 200 OK
+Date: Mon, 29 Jan 2018 00:09:09 GMT
+Content-Type: text/html; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: Fri, 01 Jan 1990 00:00:00 GMT
+Vary: Accept-Encoding, Origin
+Set-Cookie: _wt_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTllOGNkZDg3N2Y2Mzc2M2E1NWY2NTQwMjYzNzljODJhBjsAVEkiEF9jc3JmX3Rva2VuBjsARkkiMXk4YWtnZDVNYlRYUmJJWkFFaWkzVXFWM3IzbE1aU2xSbFl3SDQ3aHArbU09BjsARg%3D%3D--fe13900e81f693acb4a80d372d864c78704fa776; domain=wetransfer.com; path=/; secure; HttpOnly
+X-Request-Id: 62b0d737-b0f8-400b-ac3a-0f84acf241af
+X-Opaque: dev-1.wt-19171
+X-Runtime: 0.116529
+Strict-Transport-Security: max-age=15552000; includeSubDomains;
+

--- a/spec/sample_response_headers/headers_wetransfer_with_redirect.txt
+++ b/spec/sample_response_headers/headers_wetransfer_with_redirect.txt
@@ -1,0 +1,24 @@
+HTTP/1.1 301 Moved Permanently
+Date: Mon, 29 Jan 2018 00:42:27 GMT
+Content-Length: 0
+Connection: keep-alive
+Location: https://wetransfer.com/
+
+HTTP/1.1 200 OK
+Date: Mon, 29 Jan 2018 00:42:27 GMT
+Content-Type: text/html; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: Fri, 01 Jan 1990 00:00:00 GMT
+Vary: Accept-Encoding, Origin
+Set-Cookie: _wt_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWYyMGFmZGRlY2QyNDJkNTA3YTc2YmJmYzg2MWNhMGZlBjsAVEkiEF9jc3JmX3Rva2VuBjsARkkiMUkvMUJqR0tCelZxQytKQU1kbDV4ZW5xNDNSaUlDNnVrODhDTEY4Q0dxbXM9BjsARg%3D%3D--b46297a54dd838e0c26b5559314b10deb1f59312; domain=wetransfer.com; path=/; secure; HttpOnly
+X-Request-Id: 09e7a0ef-e9a1-4519-a580-8185e6d64c1c
+X-Opaque: dev-1.wt-24185
+X-Runtime: 0.102958
+Strict-Transport-Security: max-age=15552000; includeSubDomains;
+

--- a/spec/sample_response_headers/headers_with_set_cookie.txt
+++ b/spec/sample_response_headers/headers_with_set_cookie.txt
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK 
+Content-Type: text/plain
+Server: WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22) OpenSSL/1.0.2k
+Date: Mon, 29 Jan 2018 01:50:54 GMT
+Content-Length: 3
+Connection: Keep-Alive
+Set-Cookie: a=1
+Set-Cookie: b=2
+

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -186,6 +186,12 @@ describe Patron::Session do
     expect(body.path).to be == "/test"
   end
 
+  it "should not keep the Location header from the redirecting response" do
+    @session.max_redirects = 1
+    response = @session.get("/redirect")
+    expect(response.headers['Location']).to be_nil
+  end
+
   it "should include redirect count in response" do
     @session.max_redirects = 1
     response = @session.get("/redirect")

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -66,8 +66,8 @@ class GzipServlet < HTTPServlet::AbstractServlet
     
     content_length = out.size
     # Content-Length gets set automatically by WEBrick, and if we do it manually
-    # here then two headers will be set.
-    # res.header['Content-Length'] = content_length
+    # here then two headers will be set. This is also against the content encoding
+    # description in the HTTP 1.1 RFC - but hey, Webrick!
     res.header['Content-Encoding'] = 'deflate'
     res.header['Vary'] = 'Accept-Encoding'
     res.body = out.string


### PR DESCRIPTION
libCURL passes a string of multiple HTTP responses strung together to
the caller. The caller then has to parse out the separate responses from
that string to get the correct status code etc.

Fixes #152 #153
Fixes lostisland/faraday#733