### PR TITLE
Fix a Webmock regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Replace StringScanner in HeaderParser with StringIO, fix Webmock regression when the headers string would
+  not have an empty CRLF-terminated line at the end - which would cause the parser to return a nil.
+
 ### 0.11.1
 
 * Make sure StringScanner is available to HeaderParser.

--- a/spec/header_parser_spec.rb
+++ b/spec/header_parser_spec.rb
@@ -70,4 +70,18 @@ describe Patron::HeaderParser do
     expect(second_response.headers).to be_kind_of(Array)
     expect(second_response.headers[0]).to eq("Date: Mon, 29 Jan 2018 00:09:09 GMT")
   end
+
+  it 'parses headers without the trailing CRLF from Webmock' do
+    path = File.dirname(__FILE__) + '/sample_response_headers/webmock_headers_without_trailing_crlf.txt'
+    responses = Patron::HeaderParser.parse(File.read(path))
+
+    expect(responses.length).to eq(1)
+    first_response = responses[0]
+
+    expect(first_response.status_line).to eq("HTTP/1.1 200 OK")
+    expect(first_response.headers).to be_kind_of(Array)
+    expect(first_response.headers).not_to be_empty
+    last_header = first_response.headers[-1]
+    expect(last_header).to eq('Connection: Close')
+  end
 end

--- a/spec/sample_response_headers/webmock_headers_without_trailing_crlf.txt
+++ b/spec/sample_response_headers/webmock_headers_without_trailing_crlf.txt
@@ -1,0 +1,15 @@
+HTTP/1.1 200 OK
+Cache-Control: max-age=0, private, must-revalidate
+Content-Type: application/json; charset=utf-8
+Date: Mon, 31 Mar 2014 09:06:55 GMT
+Etag: "99914b932bd37a50b983c5e7c90ae93b"
+Status: 200 OK
+Strict-Transport-Security: max-age=31536000
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Request-Id: 58f4c05f-0f35-4957-ad73-1c6eb25ff1cc
+X-Runtime: 0.014435
+X-Ua-Compatible: chrome=1
+X-Xss-Protection: 1; mode=block
+Transfer-Encoding: chunked
+Connection: Close


### PR DESCRIPTION
Webmock overrides a ton of the Patron session internals, and it furnishes a modified
string of headers to the internal parse_headers method. That string, unlike real libCURL
header strings, does not have the terminating CRLF at the end of the last header. Nor does
it have an empty line at the very end ending with CRLF. This led our parser to return early
since it could not find the string terminator, and the early return in the header parser
code did not return the `responses` array that was already prepared for use. Even though
this is not completely "clean" we will just use a simpler parsing approach without scans.

That said, the expectation that Webmock will keep working with the refactors we appply -
given how much private stuff they rely on - might be a little naive.

Closes #157