### PR TITLE
Make DNS cache timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Add a configuration option for CURLOPT_DNS_CACHE_TIMEOUT
+* Added `Session#dns_cache_timeout` as a config option for CURLOPT_DNS_CACHE_TIMEOUT
 
 ### 0.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add a configuration option for CURLOPT_DNS_CACHE_TIMEOUT
+
 ### 0.11.1
 
 * Make sure StringScanner is available to HeaderParser.

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -588,6 +588,11 @@ static void set_options_from_request(VALUE self, VALUE request) {
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, FIX2INT(timeout));
   }
 
+  timeout = rb_funcall(request, rb_intern("dns_cache_timeout"), 0);
+  if (RTEST(timeout)) {
+    curl_easy_setopt(curl, CURLOPT_DNS_CACHE_TIMEOUT, FIX2INT(timeout));
+  }
+
   VALUE low_speed_time = rb_funcall(request, rb_intern("low_speed_time"), 0);
   if(RTEST(low_speed_time)) {
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, FIX2LONG(low_speed_time));

--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -22,14 +22,14 @@ module Patron
 
     READER_VARS = [
       :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
-      :ignore_content_length, :multipart, :action, :timeout, :connect_timeout,
+      :ignore_content_length, :multipart, :action, :timeout, :connect_timeout, :dns_cache_timeout,
       :max_redirects, :headers, :auth_type, :upload_data, :buffer_size, :cacert,
       :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4, :download_byte_limit,
       :low_speed_time, :low_speed_limit, :progress_callback
     ]
 
     WRITER_VARS = [
-      :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure,
+      :url, :username, :password, :file_name, :proxy, :proxy_type, :insecure, :dns_cache_timeout,
       :ignore_content_length, :multipart, :cacert, :ssl_version, :http_version, :automatic_content_encoding, :force_ipv4, :download_byte_limit,
       :low_speed_time, :low_speed_limit, :progress_callback
     ]

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -19,6 +19,9 @@ module Patron
     # @return [Integer] HTTP transaction timeout in seconds. Defaults to 5 seconds.
     attr_accessor :timeout
 
+    # @return [Integer] DNS cache timeout in seconds. Defaults to 60 seconds. Set to 0 for no cache, or to -1 for indefinite caching.
+    attr_accessor :dns_cache_timeout
+
     # Maximum number of redirects to follow
     # Set to 0 to disable and -1 to follow all redirects. Defaults to 5.
     # @return [Integer]
@@ -361,6 +364,7 @@ module Patron
         req.automatic_content_encoding = options.fetch :automatic_content_encoding, self.automatic_content_encoding
         req.timeout                = options.fetch :timeout,               self.timeout
         req.connect_timeout        = options.fetch :connect_timeout,       self.connect_timeout
+        req.dns_cache_timeout      = options.fetch :dns_cache_timeout,     self.dns_cache_timeout
         req.low_speed_time         = options.fetch :low_speed_time,        self.low_speed_time
         req.low_speed_limit        = options.fetch :low_speed_limit,       self.low_speed_limit
         req.force_ipv4             = options.fetch :force_ipv4,            self.force_ipv4

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -166,6 +166,11 @@ describe Patron::Session do
     expect(body.header["x-test"]).to be == ["Testing"]
   end
 
+  it "accepts the DNS cache timeout option" do
+    @session.dns_cache_timeout = 60
+    @session.get("/")
+  end
+
   it "should raise an exception on timeout" do
     @session.timeout = 1
     expect {@session.get("/timeout")}.to raise_error(Patron::TimeoutError)
@@ -551,6 +556,7 @@ describe Patron::Session do
 
     let(:args) { {
         :timeout => 10,
+        :dns_cache_timeout => 10,
         :base_url => 'http://localhost:9001',
         :headers => {'User-Agent' => 'myapp/1.0'}
     } }
@@ -563,6 +569,10 @@ describe Patron::Session do
 
     it 'sets timeout' do
       expect(session.timeout).to be == args[:timeout]
+    end
+
+    it 'sets DNS cache timeout' do
+      expect(session.dns_cache_timeout).to be == args[:dns_cache_timeout]
     end
 
     it 'sets headers' do


### PR DESCRIPTION
We need to be able to change the DNS cache value since our service discovery works on DNS, and clusters get reconfigured fairly often. So it would help if this option were provided.