### PR TITLE
Allow timeouts to be set to sub-second values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.13.0
+
+* Permit timeouts to be set as a Float of seconds and use `CURLOPT_(CONNECT)TIMEOUT_MS` instead of `CURLOPT_(CONNECT)TIMEOUT` so that
+  sub-second timeouts can be configured, which is useful for performant services using accelerated DNS resolution.
+* Remove the restriction that `Session#timeout` should be non-zero - a timeout set to 0 means "no timeout" in libCURL
+
 ### 0.12.1
 
 * Ensure HTTP2 response headers/status lines are correctly handled

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -401,6 +401,12 @@ static void set_request_body_file(struct patron_curl_state* state, VALUE r_path_
   #endif
 }
 
+static long floating_rb_seconds_to_milliseconds(VALUE r_seconds) {
+  double seconds_f = NUM2DBL(r_seconds);
+  long millis = seconds_f * (double)1000.0;
+  return millis;
+}
+
 static void set_request_body(struct patron_curl_state* state, VALUE stringable_or_file) {
   CURL* curl = state->handle;
   if(rb_respond_to(stringable_or_file, rb_intern("to_path"))) {
@@ -580,12 +586,12 @@ static void set_options_from_request(VALUE self, VALUE request) {
     
   timeout = rb_funcall(request, rb_intern("timeout"), 0);
   if (RTEST(timeout)) {
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, FIX2INT(timeout));
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, floating_rb_seconds_to_milliseconds(timeout));
   }
 
   timeout = rb_funcall(request, rb_intern("connect_timeout"), 0);
   if (RTEST(timeout)) {
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, FIX2INT(timeout));
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, floating_rb_seconds_to_milliseconds(timeout));
   }
 
   timeout = rb_funcall(request, rb_intern("dns_cache_timeout"), 0);

--- a/lib/patron/request.rb
+++ b/lib/patron/request.rb
@@ -88,26 +88,28 @@ module Patron
       @action = action.downcase.to_sym
     end
 
-    # Sets the read timeout for the CURL request, in seconds
+    # Sets the read timeout for the CURL request, in seconds.
+    # Can be set to less than a second using a floating-point value.
+    # Setting the value to 0 will disable the timeout.
     #
     # @param new_timeout[Integer] the number of seconds to wait before raising a timeout error
     def timeout=(new_timeout)
-      if new_timeout && new_timeout.to_i < 1
-        raise ArgumentError, "Timeout must be a positive integer greater than 0"
+      if new_timeout && new_timeout.to_f < 0
+        raise ArgumentError, "Timeout must be a positive number"
       end
-
-      @timeout = new_timeout.to_i
+      @timeout = new_timeout.to_f
     end
 
     # Sets the connect timeout for the CURL request, in seconds.
+    # Can be set to less than a second using a floating-point value.
     #
     # @param new_timeout[Integer] the number of seconds to wait before raising a timeout error
     def connect_timeout=(new_timeout)
-      if new_timeout && new_timeout.to_i < 1
-        raise ArgumentError, "Timeout must be a positive integer greater than 0"
+      if new_timeout && new_timeout.to_f < 0
+        raise ArgumentError, "Timeout must be a positive number"
       end
 
-      @connect_timeout = new_timeout.to_i
+      @connect_timeout = new_timeout.to_f
     end
     
     # Sets the maximum number of redirects that are going to be followed.

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -27,10 +27,6 @@ describe Patron::Request do
       expect {@request.timeout = -1}.to raise_error(ArgumentError)
     end
 
-    it "should raise an exception when assigned 0" do
-      expect {@request.timeout = 0}.to raise_error(ArgumentError)
-    end
-
   end
 
   describe :max_redirects do

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -173,7 +173,12 @@ describe Patron::Session do
 
   it "should raise an exception on timeout" do
     @session.timeout = 1
-    expect {@session.get("/timeout")}.to raise_error(Patron::TimeoutError)
+    expect {@session.get("/timeout?millis=1100")}.to raise_error(Patron::TimeoutError)
+  end
+
+  it "should raise an exception on a sub-second timeout" do
+    @session.timeout = 0.3
+    expect {@session.get("/timeout?millis=400")}.to raise_error(Patron::TimeoutError)
   end
 
   it "should raise an exception on timeout when reading from a slow resource" do

--- a/spec/session_ssl_spec.rb
+++ b/spec/session_ssl_spec.rb
@@ -73,7 +73,9 @@ describe Patron::Session do
 
   it "should raise an exception on timeout" do
     @session.timeout = 1
-    expect {@session.get("/timeout")}.to raise_error(Patron::TimeoutError)
+    expect {
+      @session.get("/timeout?millis=1100")
+    }.to raise_error(Patron::TimeoutError)
   end
 
   it "should follow redirects by default" do

--- a/spec/support/config.ru
+++ b/spec/support/config.ru
@@ -51,7 +51,9 @@ GzipServlet = Proc.new {|env|
 }
 
 TimeoutServlet = Proc.new {|env|
-  sleep 1.1
+  query_vars = Rack::Utils.parse_nested_query(env.fetch('QUERY_STRING'))
+  query_millis = query_vars.fetch('millis').to_i
+  sleep(query_millis / 1000.0)
   [200, {'Content-Type' => 'text/plain'}, ['That took a while']]
 }
 


### PR DESCRIPTION
When dealing with fast services it is reasonable to be willing to
limit the timeout to a smaller value than 1 second. We run services
that are fine with 40ms-200ms response times, and if they go over
that they cause upstream latencies to shoot up. We can switch
to using the _MS timeout settings of libCURL to be able to set
the timeouts with Float values. This gives us the possibility to
tighten up the timeouts.

Also removes the artificial restriction on the timeout not being 0
since in libCURL a timeout of 0 means "no timeout" and that could
also be a legitimate user need.