### PR TITLE
Document and clean up connection reuse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,3 @@ rvm:
 sudo: false
 dist: trusty
 cache: bundler
-install:
-  - gem update --system 2.6.12  # https://github.com/rubygems/rubygems/issues/2024
-  - gem install bundler
-  - "bundle install --verbose --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}"

--- a/README.md
+++ b/README.md
@@ -50,10 +50,52 @@ You can ship custom headers with a single request:
 
     sess.post("/foo/stuff", "some data", {"Content-Type" => "text/plain"})
 
-## Known issues
+## Threading
 
-Currently, [an issue is at play](https://github.com/curl/curl/issues/788) with OSX builds of `curl` which use Apple's SecureTransport. Such builds (which Patron is linking to), are causing segfaults when performing HTTPS requests in forked subprocesses. If you need to check whether your
-system is affected, run the Patron test suite by performing
+By itself, the `Patron::Session` objects are not thread safe (each `Session` holds a single `curl_state` pointer
+from initialization to garbage collection). At this time, Patron has no support for `curl_multi_*` family of functions 
+for doing concurrent requests. However, the actual code that interacts with libCURL does unlock the RVM GIL,
+so using multiple `Session` objects in different threads actually enables a high degree of parallelism.
+For sharing a resource of sessions between threads we recommend using the excellent [connection_pool](https://rubygems.org/gems/connection_pool) gem by Mike Perham.
+
+    patron_pool = ConnectionPool.new(size: 5, timeout: 5) { Patron::Session.new }
+    patron_pool.with do |session|
+      session.get(...)
+    end
+
+Sharing Session objects between requests will also allow you to benefit from persistent connections (connection reuse), see below.
+
+## Persistent connections
+
+Patron follows the libCURL guidelines on [connection reuse.](https://ec.haxx.se/libcurl-connectionreuse.html) If you create the Session
+object once and use it for multiple requests, the same libCURL handle is going to be used across these requests and if requests go to
+the same hostname/port/protocol the connection should get reused.
+
+## Performance with parallel requests
+
+When performing the libCURL request, Patron goes out of it's way to unlock the GVL (global VM lock) to allow other threads to be scheduled
+in parallel. The GVL is going to be released when the libCURL request starts, and will then be shortly re-acquired to provide the progress
+callback - if the callback has been configured, and then released again until the libCURL request has been performed and the response has
+been read in full. This allows one to execute multiple libCURL requests in parallel, as well as perform other activities on other MRI threads
+that are currently active in the process.
+
+## Requirements
+
+Patron uses encoding features of Ruby, so you need at least Ruby 1.9. Also, a
+recent version of libCURL is required. We recommend at least 7.19.4 because
+it [supports limiting the protocols](https://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html),
+and that is very important for security - especially if you follow redirects. 
+
+On OSX the provided libcurl is sufficient if you are not using fork+SSL combination (see below).
+You will have to install the libcurl development packages on Debian or Ubuntu. Other Linux systems are probably
+similar. For Windows we do not have an established build instruction at the moment, unfortunately.
+
+## Forking webservers on macOS and SSL
+
+Currently, [an issue is at play](https://github.com/curl/curl/issues/788) with OSX builds of `curl` which use
+Apple's SecureTransport. Such builds (which Patron is linking to), are causing segfaults when performing HTTPS
+requests in forked subprocesses. If you need to check whether your system is affected,
+run the Patron test suite by performing
 
     $ bundle install && bundle exec rspec
 
@@ -76,30 +118,6 @@ You can also save this parameter for all future Bundler-driven gem installs by
 setting this flag in Bundler proper:
 
     $ bundle config build.patron --with-curl-config=/usr/local/opt/curl-openssl/bin/curl-config
-
-## Threading
-
-By itself, the `Patron::Session` objects are not thread safe (each `Session` holds a single `curl_state` pointer
-during the request/response cycle). At this time, Patron has no support for `curl_multi_*` family of functions 
-for doing concurrent requests. However, the actual code that interacts with libCURL does unlock the RVM GIL,
-so using multiple `Session` objects in different threads is possible with a high degree of concurrency.
-For sharing a resource of sessions between threads we recommend using the excellent [connection_pool](https://rubygems.org/gems/connection_pool) gem by Mike Perham.
-
-    patron_pool = ConnectionPool.new(size: 5, timeout: 5) { Patron::Session.new }
-    patron_pool.with do |session|
-      session.get(...)
-    end
-
-## Requirements
-
-Patron uses encoding features of Ruby, so you need at least Ruby 1.9. Also, a
-recent version of libCURL is required. We recommend at least 7.19.4 because
-it [supports limiting the protocols](https://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html),
-and that is very important for security - especially if you follow redirects. 
-
-On OSX the provided libcurl is sufficient. You will have to install the libcurl
-development packages on Debian or Ubuntu. Other Linux systems are probably
-similar. For Windows we do not have an established build instruction at the moment, unfortunately.
 
 ## Installation
 

--- a/patron.gemspec
+++ b/patron.gemspec
@@ -36,7 +36,7 @@ SecureTransport-based builds might cause crashes in forking environment.
 For more info see https://github.com/curl/curl/issues/788
 }
   spec.add_development_dependency "rake", "~> 10"
-  spec.add_development_dependency "bundler", ">= 1"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rspec", ">= 2.3.0"
   spec.add_development_dependency "simplecov", "~> 0.10"
   spec.add_development_dependency "yard", "~> 0.9.11"


### PR DESCRIPTION
During a recent investigation we had questions whether
Patron is actually keepalive-friendly. It turned out that
it totally is, but there are a few bits which can be
made less tricky than they were. So:

* Document connection reuse as it is implemented in Patron
* Init the libCURL handle when Session gets created, not lazily

Lazy initialization, although economical, can lead to strange
situations with debugging, and as there already is a lifecycle
we observe (alloc/free via MRI C API) we can just as well init
the libCURL handle there