### PR TITLE
Cleanup older rubies preparing for 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ that are currently active in the process.
 
 ## Requirements
 
-Patron uses encoding features of Ruby, so you need at least Ruby 1.9. Also, a
-recent version of libCURL is required. We recommend at least 7.19.4 because
+Patron 1.0 and up requires MRI Ruby 2.3 or newer. The 0.x versions support
+Ruby 1.9.3 and these versions get tagged and developed on the `v0.x` branch.
+
+A recent version of libCURL is required. We recommend at least 7.19.4 because
 it [supports limiting the protocols](https://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html),
 and that is very important for security - especially if you follow redirects. 
 

--- a/ext/patron/extconf.rb
+++ b/ext/patron/extconf.rb
@@ -19,9 +19,4 @@ if CONFIG['CC'] =~ /gcc/
   $CFLAGS << ' -pedantic -Wall'
 end
 
-$defs.push("-DUSE_TBR")
-$defs.push("-DHAVE_THREAD_H") if have_header('ruby/thread.h')
-$defs.push("-DHAVE_TBR") if have_func('rb_thread_blocking_region', 'ruby.h')
-$defs.push("-DHAVE_TCWOGVL") if have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')
-
 create_makefile 'patron/session_ext'

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -119,9 +119,10 @@ static int session_progress_handler(void* clientp, size_t dltotal, size_t dlnow,
 }
 
 
-/*----------------------------------------------------------------------------*/
-/* List of active curl sessions                                               */
-
+/*
+  List of active curl sessions, used exclusively to be able to set interrupts
+  for all of them if the Ruby interpreter gets shut down with libCURL requests still in flight.
+*/
 struct patron_curl_state_list {
   struct patron_curl_state       *state;
   struct patron_curl_state_list  *next;

--- a/lib/patron/version.rb
+++ b/lib/patron/version.rb
@@ -1,3 +1,3 @@
 module Patron
-  VERSION = "0.13.2"
+  VERSION = "1.0.0.alpha.1"
 end


### PR DESCRIPTION
On 2.3+ upwards we don't need to check for
header presence as those headers are always
available. We can also unify and simplify
GVL lock/unlock to one set of functions.