### PR TITLE
Add licensing information to gemspec.

### DIFF
--- a/patron.gemspec
+++ b/patron.gemspec
@@ -6,6 +6,7 @@ require 'patron/version'
 Gem::Specification.new do |spec|
   spec.name        = "patron"
   spec.version     = Patron::VERSION
+  spec.licenses    = ["MIT"]
   spec.platform    = Gem::Platform::RUBY
   spec.authors     = ["Phillip Toland"]
   spec.email       = ["phil.toland@gmail.com"]


### PR DESCRIPTION
This should make it easier for automated tools to find out what license is used.