### PR TITLE
gemspec: Avoid a "*spec" typo

### DIFF
--- a/patron.gemspec
+++ b/patron.gemspec
@@ -14,12 +14,12 @@ Gem::Specification.new do |spec|
   spec.summary     = "Patron HTTP Client"
   spec.description = "Ruby HTTP client library based on libcurl"
 
-  # Prevent pushing this gem to RubyGemspec.org. To allow pushes either set the 'allowed_push_host'
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "https://rubygems.org"
   else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushespec."
+    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
   spec.required_rubygems_version = ">= 1.2.0"


### PR DESCRIPTION
Perhaps introduced in 02dc7abd8e30b0707f34bc29f91ee3623e4481c1