### PR TITLE
Add a test for a 307 redirect with a Range header

### DIFF
--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -104,6 +104,14 @@ describe Patron::Session do
     FileUtils.rm tmpfile
   end
 
+  it "should follow a 307 redirect with Range headers" do
+    tmpfile = "/tmp/picture-fragment"
+    response = @session.get_file "/redirect-to-picture", tmpfile, {'Range' => 'bytes=0-3'}
+    expect(response.body).to be_nil
+    expect(File.size(tmpfile)).to eq(4)
+    FileUtils.rm tmpfile
+  end
+
   it "downloads a very large file" do
     tmpfile = "/tmp/large-succeeded"
     @session.get_file "/very-large", tmpfile

--- a/spec/support/config.ru
+++ b/spec/support/config.ru
@@ -102,7 +102,13 @@ RepetitiveHeaderServlet = Proc.new {|env|
 }
 
 PictureServlet = Proc.new {|env|
-  [200, {'Content-Type' => 'image/png'}, [File.read('./pic.png')]]
+  # Rack::File allows us to test Range support as well
+  env_with_adjusted_path = env.merge('PATH_INFO' => Rack::Utils.escape('/pic.png'))
+  Rack::File.new('./').call(env_with_adjusted_path)
+}
+
+RedirectToPictureServlet = Proc.new {|env|
+  [307, {'Location' => '/picture'}, []]
 }
 
 WrongContentLengthServlet = Proc.new {|env|
@@ -130,6 +136,7 @@ run Rack::URLMap.new({
   "/redirect" => RedirectServlet,
   "/evil-redirect" => EvilRedirectServlet,
   "/picture" => PictureServlet,
+  "/redirect-to-picture" => RedirectToPictureServlet,
   "/very-large" => LargeServlet,
   "/setcookie" => SetCookieServlet,
   "/repetitiveheader" => RepetitiveHeaderServlet,


### PR DESCRIPTION
We needed to ensure libcurl follows through with forwarding the Range header on
a redirect, and it seems useful to have verified in the specs here as well.