### PR TITLE
Migrate CI to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1]
+
+    name: Specs - Ruby ${{ matrix.ruby-version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install libcurl
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install libcurl4 libcurl4-openssl-dev 
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run tests
+      run: bundle exec rake

--- a/lib/patron/session.rb
+++ b/lib/patron/session.rb
@@ -146,9 +146,9 @@ module Patron
       if file_path
         path = Pathname(file_path).expand_path
         
-        if !File.exists?(file_path) && !File.writable?(path.dirname)
+        if !File.exist?(file_path) && !File.writable?(path.dirname)
           raise ArgumentError, "Can't create file #{path} (permission error)"
-        elsif File.exists?(file_path) && !File.writable?(file_path)
+        elsif File.exist?(file_path) && !File.writable?(file_path)
           raise ArgumentError, "Can't read or write file #{path} (permission error)"
         end
       else

--- a/patron.gemspec
+++ b/patron.gemspec
@@ -35,7 +35,7 @@ SecureTransport-based builds might cause crashes in forking environment.
 
 For more info see https://github.com/curl/curl/issues/788
 }
-  spec.add_development_dependency "rake", "~> 12.3.3"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rspec", ">= 2.3.0"
   spec.add_development_dependency "simplecov", "~> 0.10"


### PR DESCRIPTION
Migrate CI to GitHub Actions now that Travis CI.org is inactive.

In addition to adding a basic `ci.yml` file, I needed to make several other changes:

1. Loosen the development dependency on `rake` to allow more recent versions
2. Wrap the use of `YAML::load` in the specs in a helper function that allows us to explicitly use `YAML::safe_load` with `OpenStruct` as a permitted class for Ruby 3.1 and up
3. Replace `File.exists?` with `File.exist?`

Ruby head is still failing because of a process start race condition between the `PatronTestServer` and the actual specs.  In the interest of getting something working quickly I temporarily removed `ruby-head`.  All other Rubies in the CI file are green.