### PR TITLE
Lower the /slow endpoint respond time

### DIFF
--- a/spec/support/config.ru
+++ b/spec/support/config.ru
@@ -67,7 +67,7 @@ TimeoutServlet = Proc.new {|env|
 SlowServlet = Proc.new {|env|
   body = Enumerator.new do |y|
     y.yield 'x'
-    sleep 20
+    sleep 5
     y.yield 'rest of body'
   end
   [200, {'Content-Type' => 'text/plain'}, body]


### PR DESCRIPTION
sleep 20 is unnecessary big, tests are too slow because of that
