### PR TITLE
Get rid of curl_easy_reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Sharing Session objects between requests will also allow you to benefit from per
 
 ## Persistent connections
 
-Patron follows the libCURL guidelines on [connection reuse.](https://ec.haxx.se/libcurl-connectionreuse.html) If you create the Session
+Patron follows the libCURL guidelines on [connection reuse.](https://everything.curl.dev/libcurl/connectionreuse.html) If you create the Session
 object once and use it for multiple requests, the same libCURL handle is going to be used across these requests and if requests go to
 the same hostname/port/protocol the connection should get reused.
 

--- a/ext/patron/extconf.rb
+++ b/ext/patron/extconf.rb
@@ -19,4 +19,8 @@ if CONFIG['CC'] =~ /gcc/
   $CFLAGS << ' -pedantic -Wall'
 end
 
+if CONFIG['CC'] =~ /clang/
+  $CFLAGS << ' -pedantic -Wall -Wno-void-pointer-to-enum-cast'
+end
+
 create_makefile 'patron/session_ext'

--- a/ext/patron/session_ext.c
+++ b/ext/patron/session_ext.c
@@ -77,7 +77,7 @@ static size_t file_write_handler(void* stream, size_t size, size_t nmemb, FILE* 
 static int call_user_rb_progress_blk(void* vd_curl_state) {
   struct patron_curl_state* state = (struct patron_curl_state*)vd_curl_state;
   // Invoke the block with the array
-  VALUE blk_result = rb_funcall(state->user_progress_blk,
+  rb_funcall(state->user_progress_blk,
     rb_intern("call"), 4,
     LONG2NUM(state->dltotal),
     LONG2NUM(state->dlnow),
@@ -759,10 +759,10 @@ static VALUE create_response(VALUE self, CURL* curl, VALUE header_buffer, VALUE 
   args[0] = rb_str_new2(effective_url);
 
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
-  args[1] = INT2NUM(code);
+  args[1] = LONG2NUM(code);
 
   curl_easy_getinfo(curl, CURLINFO_REDIRECT_COUNT, &count);
-  args[2] = INT2NUM(count);
+  args[2] = LONG2NUM(count);
 
   args[3] = header_buffer;
   args[4] = body_buffer;

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -262,7 +262,11 @@ describe Patron::Session do
       callback_args << [dltotal, dlnow, ultotal, ulnow]
     }
     session.get("/slow")
+    expect(callback_args).not_to be_empty
 
+    # Make sure that the callback setting was not reset.
+    callback_args = []
+    session.get("/slow")
     expect(callback_args).not_to be_empty
   end
 

--- a/spec/session_ssl_spec.rb
+++ b/spec/session_ssl_spec.rb
@@ -253,6 +253,16 @@ describe Patron::Session do
     expect(body.request_method).to be == "GET"
   end
 
+  it "should allow to specify insecure mode per-request" do
+    @session.insecure = false
+    expect {
+      @session.request(:get, "/test", {}, insecure: true)
+    }.not_to raise_error
+    expect {
+      @session.request(:get, "/test", {})
+    }.to raise_error(Patron::Error)
+  end
+
   it "should work with different SSL versions" do
     ['TLSv1_0','TLSv1_1'].each do |version|
       @session.ssl_version = version


### PR DESCRIPTION
d297b12fb89afeea5398f1600c15db7c2935d80b introduced eager curl handle initialization and its further reusage to leverage from connection caching.

It's definitely a movement into right direction but current code has a problem: it removes all the presets from the handle with `curl_easy_reset` (though it doesn't reset caches).

There's currently a bug that resets progress callback been set in `session_alloc`.

I propose to move the initialization of option defaults and all the options which are not request-specific to `session_alloc` and apply it to another handle called `base_handle`.

Then, each request builds a duplicate of that `base_handle` and sets request-specific options on it. Connection cache is being shared using curl shared objects.

Further, I'd like to refactor `set_options_from_request` function to avoid handle duplication at all in cases when no options are overriden on request level. It'd require to rewrite all `Session` option accessors to modify on `base_handle` directly so all the session-level options will already be applied and less work needs to be done on each request.

Handle duplication: https://curl.se/libcurl/c/curl_easy_duphandle.html
Shared objects: https://curl.se/libcurl/c/curl_share_init.html