### PR TITLE
CI: add Ruby 3.2, 3.3, and fix builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1]
+        ruby-version: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3]
 
     name: Specs - Ruby ${{ matrix.ruby-version }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install libcurl
       run: |
         sudo apt-get update

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in patron.gemspec
 gemspec
+
+gem "webrick", "~> 1.8"

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,12 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in patron.gemspec
 gemspec
 
+gem "rake", ">= 12.3.3"
+gem "rspec", ">= 2.3.0"
+gem "simplecov", "~> 0.10"
+gem "yard", "~> 0.9.20"
+rack_version = RUBY_VERSION >= "3.3" ? "~> 2.2" : "~> 2.1.4"
+gem "rack", rack_version
+gem "puma", '~> 3.11'
+gem "rake-compiler"
 gem "webrick", "~> 1.8"

--- a/patron.gemspec
+++ b/patron.gemspec
@@ -35,12 +35,4 @@ SecureTransport-based builds might cause crashes in forking environment.
 
 For more info see https://github.com/curl/curl/issues/788
 }
-  spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rspec", ">= 2.3.0"
-  spec.add_development_dependency "simplecov", "~> 0.10"
-  spec.add_development_dependency "yard", "~> 0.9.20"
-  spec.add_development_dependency "rack", "~> 2.1.4"
-  spec.add_development_dependency "puma", '~> 3.11'
-  spec.add_development_dependency "rake-compiler"
 end


### PR DESCRIPTION
## Changes

This PR adds Ruby 3.2, 3.3 to test matrix

...and updates actions/checkout to latest release.

...and adds `webrick` to `Gemfile` for testing purposes.

...and chooses rack-2.2 for Ruby 3.3.

## Test failures fixed

<details>

Puma and rack and rackup are running older versions, so they're compatible with older versions of Ruby.

Here, though, we fail: when referring to this code


https://github.com/toland/patron/blob/master/spec/support/config.ru#L129-L145

In 3.3, we fail tests with this:

```
An error occurred while loading ./spec/header_parser_spec.rb.
Failure/Error: APP = Rack::Builder.new { eval(File.read(File.join(__dir__, 'config.ru'))) }

ArgumentError:
  wrong number of arguments (given 3, expected 1..2)
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/urlmap.rb:41:in `initialize'
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/urlmap.rb:41:in `new'
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/urlmap.rb:41:in `block in remap'
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/urlmap.rb:28:in `each'
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/urlmap.rb:28:in `map'
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/urlmap.rb:28:in `remap'
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/urlmap.rb:23:in `initialize'
# (eval at ./spec/support/test_server.rb:6):129:in `new'
# (eval at ./spec/support/test_server.rb:6):129:in `block in <class:PatronTestServer>'
# ./spec/support/test_server.rb:6:in `eval'
# ./spec/support/test_server.rb:6:in `block in <class:PatronTestServer>'
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/builder.rb:71:in `instance_eval'
# ./vendor/bundle/ruby/3.3.0/gems/rack-2.1.4.4/lib/rack/builder.rb:71:in `initialize'
# ./spec/support/test_server.rb:6:in `new'
# ./spec/support/test_server.rb:6:in `<class:PatronTestServer>'
# ./spec/support/test_server.rb:5:in `<top (required)>'
# ./spec/spec_helper.rb:19:in `block in <top (required)>'
# ./spec/spec_helper.rb:19:in `each'
# ./spec/spec_helper.rb:19:in `<top (required)>'
# ./spec/header_parser_spec.rb:1:in `<top (required)>'
```

Aha, that was `        match = Regexp.new("^#{Regexp.quote(location).gsub('/', '/+')}(.*)", nil, 'n')` in Rack::URLMap! 

</details>

Solution: make it possible to pick a slightly newer Rack for Ruby 3.3.