### PR TITLE
Prepare 0.13.4 for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3]
+        ruby-version: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4.1]
 
     name: Specs - Ruby ${{ matrix.ruby-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+### 0.13.4
+
+* Format README a bit better using code fences
+* Depend explicitly on base64 for running tests
+* Remove C code used for Ruby support below < 2.4 (GVL unlock etc.) and drop support for these versions
+* In tests, close Tempfiles before allowing libcurl to use them (cookie jar)
+* Fix incorrect ptr type in uses of `curl_easy_escape` / `_unescape`
+* Define methods on `Session` as private instance methods from C instead of privatising them from Ruby
+* Speed up the /slow endpoint test
+* Remove use of `curl_easy_reset`. This should fix the bug with sessions resetting each other's state during `session_free`
+
+### 0.13.3
+
+* Run Puma test servers in separate processes instead of threads
+
 ### 0.13.2
 
 * Eagerly initialize libCURL handle when creating the Session instance instead of initializing it lazily

--- a/lib/patron/version.rb
+++ b/lib/patron/version.rb
@@ -1,3 +1,3 @@
 module Patron
-  VERSION = "1.0.0.alpha.1"
+  VERSION = "0.13.3"
 end

--- a/lib/patron/version.rb
+++ b/lib/patron/version.rb
@@ -1,3 +1,3 @@
 module Patron
-  VERSION = "0.13.3"
+  VERSION = "0.13.4"
 end

--- a/patron.gemspec
+++ b/patron.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version     = Patron::VERSION
   spec.licenses    = ["MIT"]
   spec.platform    = Gem::Platform::RUBY
-  spec.authors     = ["Phillip Toland"]
-  spec.email       = ["phil.toland@gmail.com"]
+  spec.authors     = ["Aeryn Riley Dowling-Toland"]
+  spec.email       = ["aeryn.toland@gmail.com"]
   spec.homepage    = "https://github.com/toland/patron"
   spec.summary     = "Patron HTTP Client"
   spec.description = "Ruby HTTP client library based on libcurl"
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.extensions   = ["ext/patron/extconf.rb"]
   spec.post_install_message = %q{
 Thank you for installing Patron. On OSX, make sure you are using libCURL with OpenSSL.
-SecureTransport-based builds might cause crashes in forking environment.
+SecureTransport-based builds might cause crashes in forking environments.
 
 For more info see https://github.com/curl/curl/issues/788
 }

--- a/spec/support/config.ru
+++ b/spec/support/config.ru
@@ -117,10 +117,11 @@ WrongContentLengthServlet = Proc.new {|env|
 
 # Serves a substantial amount of data
 LargeServlet = Proc.new {|env|
+  rng = Random.new
   len = 15 * 1024 * 1024
   body = Enumerator.new do |y|
     15.times do
-      y.yield(Random.new.bytes(1024 * 1024))
+      y.yield(rng.bytes(1024 * 1024))
     end
   end
   [200, {'Content-Type' => 'binary/octet-stream', 'Content-Length' => len.to_s}, body]


### PR DESCRIPTION
As reasonably noted in #196 we haven't had a release in a while. Let's roll one.

I've reverted my stupid alpha version designator from version.rb and annotated the changes I could parse from the commit logs in CHANGELOG. I also noticed one of the get_file tests is failing on CI, I suspect it is either Linux-related or libCURL related since we set our buffers rather small. @marshall-lee if you have ideas why this would match exactly on Darwin but not on GH actions - let me know, it would be unfortunate if we are miscounting buffers someplace.

I've also taken the liberty to replace our `tmpfile` path usage with actual tempfiles (also with a `#close` like in recent @marshall-lee changes).